### PR TITLE
Add azure function for feed aggregator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+name: Main workflow
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  AZURE_FUNCTIONAPP_NAME: PlanetXamarinFeed
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: './output'
+  DOTNET_VERSION: '3.1.x'
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  build-and-deploy:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@main
+
+    - name: Setup dotnet ${{ env.DOTNET_VERSION }} Environment
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: 'Build'
+      run: |
+        dotnet build --configuration Release
+
+    - name: '.NET Publish'
+      run: |
+        dotnet publish --configuration Release -o ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+
+    - name: 'Run Azure Functions Action'
+      uses: Azure/functions-action@v1
+      with:
+        app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        package: '${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
+        publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}

--- a/Authors/AlejandroRuiz.json
+++ b/Authors/AlejandroRuiz.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Alejandro",
+  "lastName": "Ruiz",
+  "tagOrBio": "Alejandro Ruiz is a Xamarin MVP, C# & Open Source Lover",
+  "stateOrRegion": "Guadalajara, Mexico",
+  "emailAddress": "alejandro@alejandroruizvarela.com",
+  "webSite": "https://alejandroruizvarela.blogspot.mx",
+  "feedUris": [
+    "https://alejandroruizvarela.blogspot.mx/rss.xml"
+  ],
+  "twitterHandle": "alejandroruizva",
+  "gravatarHash": "35d0fff7dbc133e9fe2075aa14205a57",
+  "githubHandle": "AlejandroRuiz",
+  "position": {
+    "lat": 20.66682,
+    "lon": -103.39182
+  },
+  "languageCode": "es"
+}

--- a/Authors/AnbuMani27.json
+++ b/Authors/AnbuMani27.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Anbu",
+  "lastName": "Mani",
+  "tagOrBio": "is a Microsoft MVP who Blogger, Speaker, Founder & Organizer of XMonkeys360 Community – India.",
+  "emailAddress": "anbumani@xmonkeys360.com",
+  "twitterHandle": "anbu_mani27",
+  "gravatarHash": "f97650474e4aa5b9609a28dcfdb052d4",
+  "stateOrRegion": "Chennai, India",
+  "webSite": "https://www.xmonkeys360.com/",
+  "position": {
+    "lat": 12.902749,
+    "lon": 80.190846
+  },
+  "feedUris": [
+    "https://xmonkeys360.com/feed/"
+  ],
+  "githubHandle": "AnbuMani27",
+  "languageCode": "en"
+}

--- a/Authors/Cheesebaron.json
+++ b/Authors/Cheesebaron.json
@@ -1,0 +1,19 @@
+{
+  "feedUris": [
+    "https://blog.ostebaronen.dk/feed.xml"
+  ],
+  "firstName": "Tomasz",
+  "lastName": "Cielecki",
+  "stateOrRegion": "Copenhagen, Denmark",
+  "emailAddress": "tomasz@ostebaronen.dk",
+  "tagOrBio": "Open Source all the things!",
+  "webSite": "https://blog.ostebaronen.dk",
+  "twitterHandle": "Cheesebaron",
+  "githubHandle": "Cheesebaron",
+  "gravatarHash": "f780d57997526876b0625e517c1e0884",
+  "position": {
+    "lat": 55.8019193,
+    "lon": 12.523124
+  },
+  "languageCode": "en"
+}

--- a/Authors/DamianMehers.json
+++ b/Authors/DamianMehers.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Damian",
+  "lastName": "Mehers",
+  "tagOrBio": "Independent Xamarin Developer",
+  "stateOrRegion": "Geneva, Switzerland",
+  "emailAddress": "damian@mehers.com",
+  "twitterHandle": "DamianMehers",
+  "gravatarHash": "d77613f4e20bfcae401a6bf0018a83d1",
+  "githubHandle": "DamianMehers",
+  "position": {
+    "lat": 46.3635288,
+    "lon": 6.1860801
+  },
+  "webSite": "https://damian.fyi/",
+  "feedUris": [
+    "https://damian.fyi/feed/Xamarin.xml"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/DanRigby.json
+++ b/Authors/DanRigby.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Dan",
+  "lastName": "Rigby",
+  "tagOrBio": "is a Technical Solutions Professional",
+  "stateOrRegion": "Raleigh, North Carolina",
+  "emailAddress": "Dan.Rigby@Microsoft.com",
+  "twitterHandle": "DanRigby",
+  "githubHandle": "DanRigby",
+  "gravatarHash": "f025f772418fbcfd3a1e15a74bf0f8a4",
+  "position": {
+    "lat": 35.77959,
+    "lon": -78.638179
+  },
+  "webSite": "https://danrigby.com/",
+  "feedUris": [
+    "https://feeds.feedburner.com/DanRigby"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/JesseLiberty.json
+++ b/Authors/JesseLiberty.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Jesse",
+  "lastName": "Liberty",
+  "tagOrBio": "See http://jesseliberty.me",
+  "stateOrRegion": "Massachusetts",
+  "emailAddress": "jesseliberty@gmail.com",
+  "twitterHandle": "jesseliberty",
+  "gravatarHash": "78d5b6609fe5a80ce67e9f971833a6c3",
+  "githubHandle": "JesseLiberty",
+  "position": {
+    "lat": 42.4703963,
+    "lon": -71.4477468
+  },
+  "webSite": "http://jesseliberty.me",
+  "feedUris": [
+    "https://feeds.feedburner.com/JesseLiberty-SilverlightGeek"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/JoeM-RP.json
+++ b/Authors/JoeM-RP.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Joe",
+  "lastName": "Meyer",
+  "stateOrRegion": "Chicago, IL",
+  "twitterHandle": "iwritecodesmtms",
+  "emailAddress": "joseph.w.meyer@live.com",
+  "tagOrBio": "I write code sometimes",
+  "gravatarHash": "1431dd2c4749b0a178c7a3130e71831e",
+  "webSite": "https://iwritecodesometimes.net",
+  "githubHandle": "JoeM-RP",
+  "position": {
+    "lat": 41.92,
+    "lon": -87.65
+  },
+  "feedUris": [
+    "https://iwritecodesometimes.net/feed/"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/JonDouglas.json
+++ b/Authors/JonDouglas.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Jon",
+  "lastName": "Douglas",
+  "tagOrBio": "",
+  "stateOrRegion": "Utah",
+  "emailAddress": "",
+  "twitterHandle": "_jondouglas",
+  "webSite": "https://www.jon-douglas.com/",
+  "feedUris": [
+    "https://www.jon-douglas.com/atom.xml"
+  ],
+  "gravatarHash": "83d67df0b9e002d1c55a2786aeeb0c1b",
+  "githubHandle": "JonDouglas",
+  "position": {
+    "lat": 39.32098,
+    "lon": -111.093731
+  },
+  "languageCode": "en"
+}

--- a/Authors/JuuCustodio.json
+++ b/Authors/JuuCustodio.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Juliano",
+  "lastName": "Custódio",
+  "stateOrRegion": "Alphaville - Barueri, Brasil",
+  "twitterHandle": "JuuCustodio",
+  "githubHandle": "JuuCustodio",
+  "tagOrBio": "Solutions Architect, Blogger and Speaker",
+  "emailAddress": "juliano.custodio@hotmail.com.br",
+  "gravatarHash": "71de9936f2ffbc93e9918066479331f1",
+  "position": {
+    "lat": -23.4880831,
+    "lon": -46.8496769
+  },
+  "webSite": "https://www.julianocustodio.com",
+  "feedUris": [
+    "https://julianocustodio.com/tag/xamarin/rss/"
+  ],
+  "languageCode": "pt"
+}

--- a/Authors/LeomarisReyes.json
+++ b/Authors/LeomarisReyes.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Leomaris",
+  "lastName": "Reyes",
+  "tagOrBio": "is a software engineer",
+  "stateOrRegion": "Dominican Republic",
+  "emailAddress": "reyes.leomaris@gmail.com",
+  "twitterHandle": "leomarisreyes11",
+  "gravatarHash": "ae78e84a683611c7b72c9ba829c125e0",
+  "githubHandle": "LeomarisReyes",
+  "position": {
+    "lat": 18.47088,
+    "lon": -69.911525
+  },
+  "webSite": "https://askxammy.com/",
+  "feedUris": [
+    "https://askxammy.com/feed"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/LetsCreateSeries.json
+++ b/Authors/LetsCreateSeries.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "LetsCreateSeries",
+  "lastName": "",
+  "stateOrRegion": "United States",
+  "emailAddress": "letscreate.roblox@gmail.com",
+  "tagOrBio": "Create Mobile Apps using Xamarin.Forms",
+  "webSite": "https://letscreateseries.com",
+  "twitterHandle": "LetsCre8Series",
+  "githubHandle": "LetsCreateSeries",
+  "gravatarHash": "10793693ff507eda06ff02e9855e774f",
+  "feedUris": [
+    "https://letscreateseries.com/rss"
+  ],
+  "position": {
+    "lat": 40.6331,
+    "lon": 89.3985
+  },
+  "languageCode": "en"
+}

--- a/Authors/MarcBruins.json
+++ b/Authors/MarcBruins.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Marc",
+  "lastName": "Bruins",
+  "tagOrBio": "is a native iOS/Android developer who fell in love with Xamarin",
+  "emailAddress": "marc@marcbruins.nl",
+  "twitterHandle": "MarcBruins",
+  "gravatarHash": "3795d2031be87499f76f6336ec5a3a45",
+  "stateOrRegion": "Utrecht, Netherlands",
+  "webSite": "https://www.marcbruins.nl",
+  "githubHandle": "MarcBruins",
+  "position": {
+    "lat": 53.219384,
+    "lon": 6.566502
+  },
+  "feedUris": [
+    "https://www.marcbruins.nl/feed.xml"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/MartinZikmund.json
+++ b/Authors/MartinZikmund.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Martin",
+  "lastName": "Zikmund",
+  "stateOrRegion": "Prague, Czech Republic",
+  "emailAddress": "martinzikmund@sphereline.com",
+  "tagOrBio": "is a mobile + cloud solutions developer, Microsoftie, Geocacher, regular squash player, foodie and Insanity & P90X fan",
+  "webSite": "https://blog.mzikmund.com/",
+  "twitterHandle": "MZetko",
+  "githubHandle": "MartinZikmund",
+  "gravatarHash": "d1a45c7ba013fbc3e9044ff6461f6acd",
+  "position": {
+    "lat": 50.124017,
+    "lon": 14.451934
+  },
+  "languageCode": "en",
+  "feedUris": [
+    "https://blog.mzikmund.com/feed/?lang=en_us"
+  ]
+}

--- a/Authors/Martynnw.json
+++ b/Authors/Martynnw.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Martyn",
+  "lastName": "Wiggins",
+  "tagOrBio": "Mobile Developer, Mountain Biker, Wannabe Adventurer",
+  "stateOrRegion": "Nottingham",
+  "emailAddress": "Martynnw@gmail.com",
+  "twitterHandle": "Martynnw",
+  "gravatarHash": "bf974dae53bdbf5018fbbbf928db0f4e",
+  "githubHandle": "Martynnw",
+  "position": {
+    "lat": 52.95,
+    "lon": -1.133333
+  },
+  "webSite": "https://martynnw.wordpress.com",
+  "feedUris": [
+    "https://martynnw.wordpress.com/feed/"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/MergeConflictFM.json
+++ b/Authors/MergeConflictFM.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Merge",
+  "lastName": "Conflict",
+  "stateOrRegion": "Seattle, WA",
+  "emailAddress": "mergeconflictfm@gmail.com",
+  "tagOrBio": "is a weekly development podcast hosted by Frank Krueger and James Montemagno.",
+  "webSite": "http://mergeconflict.fm",
+  "feedUris": [
+    "https://feeds.fireside.fm/mergeconflict/rss"
+  ],
+  "twitterHandle": "MergeConflictFM",
+  "gravatarHash": "24527eb9b29a8adbfc4155db4044dd3c",
+  "githubHandle": "",
+  "position": {
+    "lat": 47.60621,
+    "lon": -122.332071
+  },
+  "languageCode": "en"
+}

--- a/Authors/PieEatingNinjas.json
+++ b/Authors/PieEatingNinjas.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Pieter",
+  "lastName": "Nijs",
+  "tagOrBio": "Senior .NET Software Engineer & Competence Leader Mobile @ Ordina Belgium. Passionate about programming, especially .NET, C#, XAML, Xamarin and UWP.",
+  "stateOrRegion": "Hasselt, Belgium",
+  "emailAddress": "pieternijs@live.be",
+  "twitterHandle": "nijspieter",
+  "gravatarHash": "61c9184b95820bdbbcd51764f3b9fb6e",
+  "githubHandle": "PieEatingNinjas",
+  "position": {
+    "lat": 50.93,
+    "lon": 5.3375
+  },
+  "webSite": "https://blog.pieeatingninjas.be/",
+  "feedUris": [
+    "https://blog.pieeatingninjas.be/feed/rss"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/Prin53.json
+++ b/Authors/Prin53.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Denys",
+  "lastName": "Fiediaiev",
+  "stateOrRegion": "Ukraine",
+  "emailAddress": "fiediaiev@sbyte.dev",
+  "tagOrBio": "is a mobile developer specializing in Xamarin technology",
+  "webSite": "https://medium.com/@prin53",
+  "twitterHandle": "sbytedev",
+  "githubHandle": "Prin53",
+  "gravatarHash": "0d5df57543a53231787d7a34a9b79cd6",
+  "feedUris": [
+    "https://medium.com/feed/@prin53"
+  ],
+  "position": {
+    "lat": 50.4547,
+    "lon": 30.5238
+  },
+  "languageCode": "en"
+}

--- a/Authors/Pujolsluis.json
+++ b/Authors/Pujolsluis.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Luis",
+  "lastName": "Pujols",
+  "stateOrRegion": "United States",
+  "emailAddress": "luispujolso@gmail.com",
+  "tagOrBio": "is a Software Engineer with a passion for Mobile Development and Software Architecture. Co-organizer of the .NET Community in the Dominican Republic and a Xamarin Lover.",
+  "webSite": "https://www.pujolsluis.com/",
+  "twitterHandle": "Pujolsluis1",
+  "githubHandle": "Pujolsluis",
+  "gravatarHash": "c91c0d654f4f06ca6e7a7e54699de85d",
+  "feedUris": [
+    "https://www.pujolsluis.com/rss"
+  ],
+  "position": {
+    "lat": 26.0203048,
+    "lon": -80.115093
+  },
+  "languageCode": "en"
+}

--- a/Authors/ReactiveUI.json
+++ b/Authors/ReactiveUI.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "ReactiveUI",
+  "lastName": "",
+  "stateOrRegion": "Internet",
+  "emailAddress": "hello@reactiveui.net",
+  "tagOrBio": "An advanced, composable, functional reactive model-view-viewmodel framework for all .NET platforms",
+  "webSite": "https://reactiveui.net/",
+  "feedUris": [
+    "https://reactiveui.net/rss"
+  ],
+  "twitterHandle": "ReactiveXUI",
+  "gravatarHash": "",
+  "githubHandle": "ReactiveUI",
+  "position": {
+    "lat": -13.6981464,
+    "lon": 37.3979239
+  },
+  "languageCode": "en"
+}

--- a/Authors/Sankra.json
+++ b/Authors/Sankra.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Runar Ovesen",
+  "lastName": "Hjerpbakk",
+  "tagOrBio": "Passionate, empathic and experienced developer, software architect and manager. My love for C# is only surpassed by my love for Xamarin and iOS.",
+  "stateOrRegion": "Trondheim, Norway",
+  "emailAddress": "runar@hjerpbakk.com",
+  "twitterHandle": "hjerpbakk",
+  "gravatarHash": "62b1d11eafee92745a51971d6cc21f85",
+  "githubHandle": "Sankra",
+  "position": {
+    "lat": 63.4305,
+    "lon": 10.3951
+  },
+  "webSite": "https://hjerpbakk.com/",
+  "feedUris": [
+    "https://hjerpbakk.com/feed.xml"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/StefanRiedmann.json
+++ b/Authors/StefanRiedmann.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Stefan",
+  "githubHandle": "StefanRiedmann",
+  "lastName": "Riedmann",
+  "tagOrBio": "Growing software",
+  "stateOrRegion": "Mendoza, Argentina and Gemünden, Germany",
+  "emailAddress": "stefan.riedmann@ciclosoftware.com",
+  "twitterHandle": "CicloSoftware",
+  "webSite": "https://www.ciclosoftware.com",
+  "feedUris": [
+    "https://www.ciclosoftware.com/feed/"
+  ],
+  "gravatarHash": "2781a55d04634584326bedfe08660537",
+  "position": {
+    "lat": -32.8886904,
+    "lon": -68.8481432
+  },
+  "languageCode": "en"
+}

--- a/Authors/TheFo2sh.json
+++ b/Authors/TheFo2sh.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Ahmed",
+  "lastName": "Fouad",
+  "stateOrRegion": "Vienna, Austria",
+  "emailAddress": "ahmed.fouad.net@hotmail.com",
+  "tagOrBio": "software engineer with 10 years experience with the .NET Framework living in Vienna, Austria.",
+  "webSite": "https://itnext.com/@csharpwriter",
+  "feedUris": [
+    "https://medium.com/feed/@csharpwriter"
+  ],
+  "twitterHandle": "MCC_Ahmed",
+  "gravatarHash": "5727eb3df565991947d90ed140962472",
+  "githubHandle": "TheFo2sh",
+  "position": {
+    "lat": 48.20849,
+    "lon": 16.37208
+  },
+  "languageCode": "en"
+}

--- a/Authors/TheXamarinShow.json
+++ b/Authors/TheXamarinShow.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "The Xamarin",
+  "lastName": "Show",
+  "stateOrRegion": "Channel 9",
+  "emailAddress": "",
+  "tagOrBio": "is a Weekly Developer Show for Xamarin Developers",
+  "webSite": "http://xamarinshow.com",
+  "feedUris": [
+    "https://channel9.msdn.com/Shows/XamarinShow/feed"
+  ],
+  "twitterHandle": "TheXamarinShow",
+  "gravatarHash": "7a0c7da0279b4e90439e780fa01924e0",
+  "githubHandle": "",
+  "position": {
+    "lat": 47.645136,
+    "lon": -122.130939
+  },
+  "languageCode": "en"
+}

--- a/Authors/TomSoderling.json
+++ b/Authors/TomSoderling.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Tom",
+  "lastName": "Soderling",
+  "stateOrRegion": "Minneapolis, MN",
+  "emailAddress": "",
+  "tagOrBio": "is a Sr. Mobile Developer, speaker, and open source contributor",
+  "twitterHandle": "tomsoderling",
+  "gravatarHash": "dd103f377899fc63b0b88c5bb62b15bd",
+  "position": {
+    "lat": 44.986656,
+    "lon": -93.258133
+  },
+  "webSite": "https://tomsoderling.github.io",
+  "feedUris": [
+    "https://tomsoderling.github.io/feed.xml"
+  ],
+  "githubHandle": "TomSoderling",
+  "languageCode": "en"
+}

--- a/Authors/UdaraAlwis.json
+++ b/Authors/UdaraAlwis.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Udara",
+  "lastName": "Alwis",
+  "tagOrBio": "A mobile dev enthusiast. Xamarin Certified Developer in Singapore.",
+  "stateOrRegion": "Singapore",
+  "emailAddress": "udara.robotics@gmail.com",
+  "twitterHandle": "Udara_Alwis",
+  "gravatarHash": "125c4aaed98f2a88207dac78c17dd344",
+  "githubHandle": "UdaraAlwis",
+  "position": {
+    "lat": 1.284433,
+    "lon": 103.859609
+  },
+  "webSite": "https://theconfuzedsourcecode.wordpress.com/",
+  "feedUris": [
+    "https://theconfuzedsourcecode.wordpress.com/feed/"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/VicenteGuzman.json
+++ b/Authors/VicenteGuzman.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Vicente",
+  "lastName": "Guzman",
+  "tagOrBio": "Vicente Guzman is a Community Member / Microsoft rMVP / Software Engineer",
+  "stateOrRegion": "Ciudad de México",
+  "emailAddress": "luciomsp@geeks.ms",
+  "webSite": "https://vicenteguzman.mx/",
+  "feedUris": [
+    "https://vicenteguzman.mx/feed/"
+  ],
+  "twitterHandle": "luciomsp",
+  "gravatarHash": "72cce778aac0d6066a14225e90c30874",
+  "githubHandle": "VicenteGuzman",
+  "position": {
+    "lat": 19.432608,
+    "lon": -99.133209
+  },
+  "languageCode": "es"
+}

--- a/Authors/XamarinPodcast.json
+++ b/Authors/XamarinPodcast.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "The Xamarin",
+  "lastName": "Podcast",
+  "stateOrRegion": "Internet",
+  "emailAddress": "hello@xamarin.com",
+  "tagOrBio": "is the official Xamarin podcast discussing all things Xamarin!",
+  "webSite": "http://www.xamarinpodcast.com",
+  "feedUris": [
+    "https://feeds.fireside.fm/xamarinpodcast/rss"
+  ],
+  "twitterHandle": "XamarinPodcast",
+  "gravatarHash": "70148d964bb389d42547834e1062c886",
+  "githubHandle": "",
+  "position": {
+    "lat": -1337.0,
+    "lon": 42.0
+  },
+  "languageCode": "en"
+}

--- a/Authors/acaliaro.json
+++ b/Authors/acaliaro.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Alessandro",
+  "lastName": "Caliaro",
+  "tagOrBio": "I like Xamarin Forms and I like help other people to understand it",
+  "emailAddress": "acaliaro@libero.it",
+  "twitterHandle": "acaliaro",
+  "gravatarHash": "a7466eb1c467806f77bc692a4745d0f9",
+  "stateOrRegion": "Lissone, Italy",
+  "webSite": "https://acaliaro.wordpress.com",
+  "githubHandle": "acaliaro",
+  "position": {
+    "lat": 45.632783,
+    "lon": 9.227265
+  },
+  "feedUris": [
+    "https://acaliaro.wordpress.com/feed/"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/ahoefling.json
+++ b/Authors/ahoefling.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Andrew",
+  "lastName": "Hoefling",
+  "stateOrRegion": "New York, United States",
+  "emailAddress": "andrew@hoefling.me",
+  "tagOrBio": "Microsoft MVP (Developer Technologies) Open Source developer who loves integrating Xamarin with other platforms",
+  "webSite": "https://www.andrewhoefling.com/",
+  "twitterHandle": "andrew_hoefling",
+  "githubHandle": "ahoefling",
+  "gravatarHash": "beab68478a5128e634590af5e4f01941",
+  "feedUris": [
+    "https://www.andrewhoefling.com/feed.xml?category=xamarin&uno-platform"
+  ],
+  "position": {
+    "lat": 43.156578,
+    "lon": -77.608849
+  },
+  "languageCode": "en"
+}

--- a/Authors/akamud.json
+++ b/Authors/akamud.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Mahmoud",
+  "lastName": "Ali",
+  "stateOrRegion": "São Paulo, Brasil",
+  "emailAddress": "muddibr@gmail.com",
+  "tagOrBio": "Microsoft MVP",
+  "webSite": "https://www.lambda3.com.br/blog",
+  "twitterHandle": "akamud",
+  "githubHandle": "akamud",
+  "gravatarHash": "fc093b379c830c8105f8d15d9261a144",
+  "feedUris": [
+    "https://www.lambda3.com.br/feed/"
+  ],
+  "position": {
+    "lat": -23.552339,
+    "lon": -46.661393
+  },
+  "languageCode": "pt"
+}

--- a/Authors/alexsorokoletov.json
+++ b/Authors/alexsorokoletov.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Alexandr",
+  "lastName": "Sorokoletov",
+  "tagOrBio": "when he's not developing mobile applications enjoys snowboarding, kitesurfing and travel",
+  "stateOrRegion": "Washington, D.C.",
+  "emailAddress": "",
+  "twitterHandle": "AlexSorokoletov",
+  "githubHandle": "alexsorokoletov",
+  "position": {
+    "lat": 38.905147,
+    "lon": -77.065189
+  },
+  "webSite": "https://sorokoletov.com",
+  "feedUris": [
+    "https://sorokoletov.com/atom.xml"
+  ],
+  "gravatarHash": "b07fef8827dd03655303751e2fd5ca95",
+  "languageCode": "en"
+}

--- a/Authors/almirvuk.json
+++ b/Authors/almirvuk.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Almir",
+  "lastName": "Vuk",
+  "tagOrBio": "Software Development Engineer & Microsoft MVP, crafting apps with ASP.NET Core and Xamarin",
+  "stateOrRegion": "Mostar, Bosnia and Herzegovina",
+  "emailAddress": "almir.vuk@outlook.com",
+  "twitterHandle": "almirvuk",
+  "gravatarHash": "d58b6fd6c2d9f949345e8d14d203a4b2",
+  "webSite": "https://almirvuk.com/",
+  "feedUris": [
+    "https://almirvuk.com/rss/"
+  ],
+  "githubHandle": "almirvuk",
+  "position": {
+    "lat": 43.3395522,
+    "lon": 17.7862211
+  },
+  "languageCode": "en"
+}

--- a/Authors/andreas-nesheim.json
+++ b/Authors/andreas-nesheim.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Andreas",
+  "lastName": "Nesheim",
+  "stateOrRegion": "Norway",
+  "emailAddress": "andreas.aronsen.nesheim@gmail.com",
+  "tagOrBio": ".NET developer with a passion for Xamarin, Azure DevOps and .NET Core.",
+  "webSite": "https://www.andreasnesheim.no/",
+  "twitterHandle": "AndreasNesheim",
+  "githubHandle": "andreas-nesheim",
+  "gravatarHash": "3f1d141d2809114debffb23277e91e3e",
+  "feedUris": [
+    "https://andreasnesheim.no/feed"
+  ],
+  "position": {
+    "lat": 58.9540147,
+    "lon": 5.7259639
+  },
+  "languageCode": "en"
+}

--- a/Authors/aritchie.json
+++ b/Authors/aritchie.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Allan",
+  "lastName": "Ritchie",
+  "stateOrRegion": "Toronto, Canada",
+  "emailAddress": "allan.ritchie@gmail.com",
+  "tagOrBio": "",
+  "webSite": "https://allancritchie.net",
+  "twitterHandle": "allanritchie911",
+  "githubHandle": "aritchie",
+  "gravatarHash": "5f22bd04ca38ed4d0a5225d0825e0726",
+  "position": {
+    "lat": 43.6425701,
+    "lon": -79.3892455
+  },
+  "languageCode": "en",
+  "feedUris": [
+    "https://allancritchie.net/xamarin.rss"
+  ]
+}

--- a/Authors/asfend.json
+++ b/Authors/asfend.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Asfend Yar",
+  "lastName": "Hamid",
+  "stateOrRegion": "Lahore, Pakistan",
+  "emailAddress": "asfend@hotmail.com",
+  "tagOrBio": "is a Technical Trainer, Author at Udemy and Passionate Community Member as well as Software Engineer",
+  "webSite": "https://xamarinui.blogspot.com/",
+  "feedUris": [
+    "https://xamarinui.blogspot.com/feeds/posts/default"
+  ],
+  "twitterHandle": "asfend",
+  "gravatarHash": "1aa9a7436eec5ad5d0418a385d1bdbe0",
+  "githubHandle": "asfend",
+  "position": {
+    "lat": 31.5712,
+    "lon": 74.3646
+  },
+  "languageCode": "en"
+}

--- a/Authors/aspnetde.json
+++ b/Authors/aspnetde.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Thomas",
+  "lastName": "Bandt",
+  "stateOrRegion": "Munich, Germany",
+  "position": {
+    "lat": 48.1485869,
+    "lon": 11.5353743
+  },
+  "emailAddress": "",
+  "webSite": "https://thomasbandt.com/",
+  "tagOrBio": "Developer & Entrepreneur of Passion",
+  "twitterHandle": "asp_net",
+  "githubHandle": "aspnetde",
+  "gravatarHash": "32860557b42ace0afa72704e466e34f1",
+  "feedUris": [
+    "https://thomasbandt.com/feed"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/balivo.json
+++ b/Authors/balivo.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Jefferson",
+  "lastName": "Balivo",
+  "stateOrRegion": "Jaú, São Paulo, Brazil",
+  "emailAddress": "jefferson@balivo.com.br",
+  "tagOrBio": "Xamarin Enthusiast, Technical Lead and Cross Platform Architect, Multi-Plataform Technical Audience Contributor (MTAC), Technical Writer and Speaker",
+  "webSite": "https://balivo.com.br/",
+  "twitterHandle": "jbalivo",
+  "githubHandle": "balivo",
+  "gravatarHash": "e5a95c365e8f06786d6439474bc733df",
+  "feedUris": [
+    "https://balivo.com.br/rss"
+  ],
+  "position": {
+    "lat": -22.2997067,
+    "lon": -48.5931324
+  },
+  "languageCode": "pt"
+}

--- a/Authors/banditoth.json
+++ b/Authors/banditoth.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "András",
+  "lastName": "Tóth",
+  "tagOrBio": "also known as banditoth | Xamarin && C# .NET developer from Hungary.",
+  "stateOrRegion": "Budapest, Hungary",
+  "emailAddress": "",
+  "twitterHandle": "",
+  "githubHandle": "banditoth",
+  "position": {
+    "lat": 47.497913,
+    "lon": 19.040236
+  },
+  "webSite": "https://www.banditoth.hu",
+  "feedUris": [
+    "https://www.banditoth.hu/feed/"
+  ],
+  "gravatarHash": "e11e3fd93c1cc4db5ec6f309bac0ff4d",
+  "languageCode": "hu"
+}

--- a/Authors/basdecort.json
+++ b/Authors/basdecort.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Bas",
+  "lastName": "de Cort",
+  "stateOrRegion": "Tilburg, The Netherlands",
+  "emailAddress": "",
+  "tagOrBio": "is a mobile developer with a great passion for Xamarin 🙉",
+  "webSite": "https://www.basdecort.com",
+  "twitterHandle": "basdecort",
+  "githubHandle": "basdecort",
+  "gravatarHash": "9cabafd38c21d9df358f7532ffa39153",
+  "position": {
+    "lat": 52.040222799999995,
+    "lon": 5.5349002999999994
+  },
+  "feedUris": [
+    "https://www.basdecort.com/rss"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/bbenetskyy.json
+++ b/Authors/bbenetskyy.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Bohdan",
+  "lastName": "Benetskyi",
+  "stateOrRegion": "Rzeszow, Poland",
+  "emailAddress": "benetskyybogdan@gmail.com",
+  "tagOrBio": "Xamarin Software Developer, co-organizer of Xamarin Local Events in Rzeszow, Local CSS at Xamarin Advocate",
+  "webSite": "https://medium.com/@benetskyybogdan/",
+  "twitterHandle": "bbenetskyy",
+  "githubHandle": "bbenetskyy",
+  "gravatarHash": "8bfa7db9239c2969b79468a58c8dd066",
+  "feedUris": [
+    "https://medium.com/feed/@benetskyybogdan/"
+  ],
+  "position": {
+    "lat": 50.041187,
+    "lon": 21.999121
+  },
+  "languageCode": "en"
+}

--- a/Authors/brminnick.json
+++ b/Authors/brminnick.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Brandon",
+  "lastName": "Minnick",
+  "stateOrRegion": "San Francisco, CA",
+  "emailAddress": "brandon@codetraveler.io",
+  "tagOrBio": "works as a Developer Advocate at Microsoft. Formerly a Customer Success Engineer at Xamarin (before the Microsoft Acquisition), Brandon has a loves helping developers make 5-star apps!",
+  "webSite": "https://codetraveler.io",
+  "twitterHandle": "TheCodeTraveler",
+  "githubHandle": "brminnick",
+  "gravatarHash": "e03e28629383def59c31d54fb8bb3982",
+  "position": {
+    "lat": 37.77669,
+    "lon": -122.416644
+  },
+  "languageCode": "en",
+  "feedUris": [
+    "https://codetraveler.io/tag/xamarin/rss"
+  ]
+}

--- a/Authors/canbilgin.json
+++ b/Authors/canbilgin.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Can",
+  "lastName": "Bilgin",
+  "tagOrBio": "Seasoned microsoft stack developer with passion for mobile development. Microsoft MVP for Windows Platform Development",
+  "stateOrRegion": "Sarajevo",
+  "emailAddress": "can_bilgin@hotmail.com",
+  "twitterHandle": "can_bilgin",
+  "gravatarHash": "3659d530c25e6188f7ef4c98ed100dc8",
+  "webSite": "https://canbilgin.wordpress.com/",
+  "feedUris": [
+    "https://canbilgin.wordpress.com/feed/"
+  ],
+  "githubHandle": "canbilgin",
+  "position": {
+    "lat": 43.8938256,
+    "lon": 18.3129519
+  },
+  "languageCode": "en"
+}

--- a/Authors/chamons.json
+++ b/Authors/chamons.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Chris",
+  "lastName": "Hamons",
+  "tagOrBio": "is the lead engineer for Xamarin.Mac",
+  "stateOrRegion": "Austin, Texas",
+  "emailAddress": "chris.hamons@xamarin.com",
+  "twitterHandle": "IfErrThrowBrick",
+  "webSite": "https://medium.com/@donblas",
+  "feedUris": [
+    "https://medium.com/feed/@donblas"
+  ],
+  "gravatarHash": "8fb3e7f07ea1386cefe1326b48e0e21a",
+  "githubHandle": "chamons",
+  "position": {
+    "lat": 30.267153,
+    "lon": -97.743061
+  },
+  "languageCode": "en"
+}

--- a/Authors/char0394.json
+++ b/Authors/char0394.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Charlin",
+  "lastName": "Agramonte",
+  "tagOrBio": "Software Engineer",
+  "stateOrRegion": "Dominican Republic",
+  "emailAddress": "charlin@crossgeeks.com",
+  "twitterHandle": "Chard003",
+  "gravatarHash": "7db2bb2eed17e8df7e78b0d5461d90b0",
+  "githubHandle": "char0394",
+  "position": {
+    "lat": 18.4735438,
+    "lon": -69.9456919
+  },
+  "webSite": "https://xamgirl.com/",
+  "feedUris": [
+    "https://xamgirl.com/rss"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/cjlotz.json
+++ b/Authors/cjlotz.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Carel",
+  "lastName": "Lotz",
+  "tagOrBio": "is a Software Architect/Developer that loves to code",
+  "stateOrRegion": "Cape Town, South Africa",
+  "emailAddress": "carel.lotz@gmail.com",
+  "twitterHandle": "cjlotz",
+  "githubHandle": "cjlotz",
+  "gravatarHash": "0f692990601721c06f141f4fe860685e",
+  "position": {
+    "lat": -33.89635,
+    "lon": 18.70199
+  },
+  "webSite": "https://cjlotz.github.io",
+  "feedUris": [
+    "https://cjlotz.github.io/feed.xml"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/codemillmatt.json
+++ b/Authors/codemillmatt.json
@@ -1,0 +1,19 @@
+{
+  "feedUris": [
+    "https://codemilltech.com/feed/"
+  ],
+  "firstName": "Matthew",
+  "lastName": "Soucoup",
+  "stateOrRegion": "Madison, WI",
+  "emailAddress": "msoucoup@codemilltech.com",
+  "tagOrBio": "",
+  "webSite": "https://codemilltech.com",
+  "twitterHandle": "codemillmatt",
+  "gravatarHash": "df69069a0bffd2dae5a8700a1bef7bfd",
+  "githubHandle": "codemillmatt",
+  "position": {
+    "lat": 43.073052,
+    "lon": -89.40123
+  },
+  "languageCode": "en"
+}

--- a/Authors/crswlls.json
+++ b/Authors/crswlls.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Chris",
+  "lastName": "Williams",
+  "tagOrBio": "",
+  "emailAddress": "",
+  "twitterHandle": "crswlls",
+  "gravatarHash": "21e379df7ba9c57f167188e2fcb7dd75",
+  "stateOrRegion": "Bristol, UK",
+  "webSite": "https://crswlls.wordpress.com",
+  "feedUris": [
+    "https://crswlls.wordpress.com/rss/"
+  ],
+  "githubHandle": "",
+  "position": {
+    "lat": 30.267153,
+    "lon": -97.743061
+  },
+  "languageCode": "en"
+}

--- a/Authors/damienaicheh.json
+++ b/Authors/damienaicheh.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Damien",
+  "lastName": "Aicheh",
+  "stateOrRegion": "Rennes, France",
+  "emailAddress": "",
+  "tagOrBio": "is a passionate mobile developer also interrested about Azure, Azure DevOps and.NET Core.",
+  "webSite": "https://damienaicheh.github.io/",
+  "twitterHandle": "damienaicheh",
+  "githubHandle": "damienaicheh",
+  "gravatarHash": "b5cf688a9aa81b3ef752ecda4366a8e9",
+  "feedUris": [
+    "https://damienaicheh.github.io/feed.xml"
+  ],
+  "position": {
+    "lat": 48.1113036,
+    "lon": -1.6801598
+  },
+  "languageCode": "en"
+}

--- a/Authors/damiendoumer.json
+++ b/Authors/damiendoumer.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Damien",
+  "lastName": "Doumer",
+  "stateOrRegion": "Douala, Cameroon",
+  "emailAddress": "damientohin@gmail.com",
+  "tagOrBio": "Fresh .Net developer, who loves mobile app development.",
+  "webSite": "https://doumer.me/",
+  "feedUris": [
+    "https://doumer.me/feed/"
+  ],
+  "twitterHandle": "Damien_Doumer",
+  "gravatarHash": "ecdd93df62c61daa04da17967f82d08d",
+  "githubHandle": "damiendoumer",
+  "position": {
+    "lat": 4.07316844239285,
+    "lon": 9.6842408186165585
+  },
+  "languageCode": "en"
+}

--- a/Authors/danielcauser.json
+++ b/Authors/danielcauser.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Daniel",
+  "lastName": "Causer",
+  "stateOrRegion": "Toronto, Canada",
+  "emailAddress": "danielcauser@gmail.com",
+  "tagOrBio": "is a Xamarin Certified Developer fan of Xamarin and Mobile Development.",
+  "webSite": "https://causerexception.com/",
+  "twitterHandle": "danielcauser",
+  "githubHandle": "danielcauser",
+  "gravatarHash": "2666956714a2c2d48c480a6bddac4071",
+  "feedUris": [
+    "https://causerexception.com/feed"
+  ],
+  "position": {
+    "lat": 43.653103,
+    "lon": -79.383851
+  },
+  "languageCode": "en"
+}

--- a/Authors/danielmonettelli.json
+++ b/Authors/danielmonettelli.json
@@ -1,0 +1,20 @@
+{
+  "firstName": "Daniel Angel",
+  "lastName": "Monettelli L.",
+  "tagOrBio": "is a Software Engineer, Videoblogger, Xamarin Mobile Developer & UI/UX Architect.",
+  "stateOrRegion": "Arequipa, Perú",
+  "emailAddress": "danielmonetelli@hotmail.com",
+  "webSite": "https://danielmonettelli.github.io",
+  "feedUris": [
+    "https://danielmonettelli.github.io/feed.xml",
+    "https://www.youtube.com/feeds/videos.xml?channel_id=UCTAlbAORoFvAHj7jA4DLSFQ"
+  ],
+  "twitterHandle": "DanielMonetelli",
+  "gravatarHash": "4b3d0e60019ad8fe1e4d7cd5c8850efb",
+  "githubHandle": "danielmonettelli",
+  "position": {
+    "lat": -16.4042643,
+    "lon": -71.5486383
+  },
+  "languageCode": "en"
+}

--- a/Authors/dansiegel.json
+++ b/Authors/dansiegel.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Dan",
+  "lastName": "Siegel",
+  "stateOrRegion": "San Diego, CA",
+  "emailAddress": "dsiegel@avantipoint.com",
+  "tagOrBio": "is a Mobile App Consultant and Founder of AvantiPoint. He is an author of several OSS libraries, a maintainer of the Prism Library and a DevOps champion.",
+  "webSite": "https://dansiegel.net",
+  "feedUris": [
+    "https://dansiegel.net/syndication.axd"
+  ],
+  "twitterHandle": "DanJSiegel",
+  "gravatarHash": "b65a519785f69fbe7236dd0fd6396094",
+  "githubHandle": "dansiegel",
+  "position": {
+    "lat": 32.726308,
+    "lon": -117.177746
+  },
+  "languageCode": "en"
+}

--- a/Authors/davidbritch.json
+++ b/Authors/davidbritch.json
@@ -1,0 +1,21 @@
+{
+  "firstName": "David",
+  "lastName": "Britch",
+  "Title": "Senior Developer/Writer",
+  "stateOrRegion": "UK",
+  "emailAddress": "",
+  "twitterHandle": "britchdavid",
+  "gravatarHash": "0ddca71a03a3591203b4a748fcdfb47a",
+  "Started": "2015-06-08T00:00:00",
+  "tagOrBio": "",
+  "githubHandle": "davidbritch",
+  "position": {
+    "lat": 53.4793,
+    "lon": -2.2479
+  },
+  "webSite": "https://www.davidbritch.com",
+  "feedUris": [
+    "https://www.davidbritch.com/rss.xml"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/dhindrik.json
+++ b/Authors/dhindrik.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Daniel",
+  "lastName": "Hindrikes",
+  "stateOrRegion": "Borlänge, Sweden",
+  "emailAddress": "daniel@hindrikes.se",
+  "tagOrBio": "is an architect and developer using Xamarin and Azure. Working as a Ninja at tretton37. Also recording \"The Code Behind\" podcast!",
+  "webSite": "https://danielhindrikes.se",
+  "twitterHandle": "hindrikes",
+  "githubHandle": "dhindrik",
+  "gravatarHash": "054db2cfd79654ec5d92e20c180f2d72",
+  "feedUris": [
+    "https://danielhindrikes.se/index.php/feed/"
+  ],
+  "position": {
+    "lat": 60.48604,
+    "lon": 15.43391
+  },
+  "languageCode": "en"
+}

--- a/Authors/divikiran.json
+++ b/Authors/divikiran.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Divikiran",
+  "lastName": "Ravela",
+  "stateOrRegion": "Melbourne, Australia",
+  "emailAddress": "divikiran1@gmail.com",
+  "tagOrBio": "Xamarin Consultant/Tech Lead",
+  "webSite": "https://xamlabs.com/",
+  "twitterHandle": "",
+  "githubHandle": "divikiran",
+  "gravatarHash": "",
+  "feedUris": [
+    "https://xamlabs.com/feed/"
+  ],
+  "position": {
+    "lat": -37.8135511,
+    "lon": 144.9637748
+  },
+  "languageCode": "en"
+}

--- a/Authors/dylanberry.json
+++ b/Authors/dylanberry.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Dylan",
+  "lastName": "Berry",
+  "tagOrBio": "Genetically Predisposed Programmer",
+  "stateOrRegion": "Toronto, Canada",
+  "emailAddress": "dylanberry@gmail.com",
+  "twitterHandle": "dylbot9000",
+  "gravatarHash": "8ef85938904ff43397d50caa9b0eebed",
+  "githubHandle": "dylanberry",
+  "position": {
+    "lat": 43.653493,
+    "lon": -79.384095
+  },
+  "webSite": "https://www.dylanberry.com/",
+  "feedUris": [
+    "https://www.dylanberry.com/feed/"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/egbakou.json
+++ b/Authors/egbakou.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Kodjo Laurent",
+  "lastName": "Egbakou",
+  "stateOrRegion": "Lome, Togo",
+  "emailAddress": "laurent@lioncoding.com",
+  "tagOrBio": "is C#/.Net/Xamarin developer who learns and shares.",
+  "webSite": "https://lioncoding.com/",
+  "twitterHandle": "lioncoding",
+  "githubHandle": "egbakou",
+  "gravatarHash": "6e26a030d3b9495872b58d922bd86157",
+  "feedUris": [
+    "https://lioncoding.com/feed.xml"
+  ],
+  "position": {
+    "lat": 6.2030129,
+    "lon": 1.1918434
+  },
+  "languageCode": "fr"
+}

--- a/Authors/elbrinner.json
+++ b/Authors/elbrinner.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Elbrinner",
+  "lastName": "da Silva Fernandes",
+  "stateOrRegion": "Madrid , Spain",
+  "emailAddress": "elbrinner@elbrinner.com",
+  "tagOrBio": "is a Xamarin consultant in everis Spain and organizer of the meetup group Xamarin Madrid.",
+  "webSite": "https://www.elbrinner.com/",
+  "twitterHandle": "elbrinner",
+  "githubHandle": "elbrinner",
+  "gravatarHash": "15e64690c0e4d5b2c692e9fc7de5e768",
+  "feedUris": [
+    "https://www.elbrinner.com/rss"
+  ],
+  "position": {
+    "lat": 40.416775,
+    "lon": -3.70379
+  },
+  "languageCode": "es"
+}

--- a/Authors/felipebaltazar.json
+++ b/Authors/felipebaltazar.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Felipe",
+  "lastName": "Baltazar",
+  "tagOrBio": "Xamarin 🐒, ApnetCore 🌐, Windows 💻, Nerd 🤓, Gamer 🎮 and Father 👨‍👩‍👦",
+  "stateOrRegion": "Rio Grande do sul, Brasil",
+  "emailAddress": "felipe.dasilvabaltazar@gmail.com",
+  "twitterHandle": "FelippeBaltazar",
+  "githubHandle": "felipebaltazar",
+  "gravatarHash": "c4deac62305f590fbda80209628afd0e",
+  "position": {
+    "lat": -29.940163,
+    "lon": -51.088751
+  },
+  "webSite": "https://medium.com/@felipedasilvabaltazar",
+  "feedUris": [
+    "https://medium.com/feed/@felipedasilvabaltazar"
+  ],
+  "languageCode": "pt"
+}

--- a/Authors/filipoff2.json
+++ b/Authors/filipoff2.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Boguslaw",
+  "lastName": "Blonski",
+  "tagOrBio": "Generalist who is pragmatic and has delivered real code to real users in a variety of shapes.",
+  "stateOrRegion": "Lezajsk, Poland",
+  "emailAddress": "boguslawblonski@gmail.com",
+  "twitterHandle": "filipoff",
+  "gravatarHash": "d48c54ac95492ddadfc221b646d4c612",
+  "webSite": "https://medium.com/@boguslawblonski",
+  "feedUris": [
+    "https://medium.com/feed/@boguslawblonski/"
+  ],
+  "githubHandle": "filipoff2",
+  "position": {
+    "lat": 50.2684647,
+    "lon": 22.3819053
+  },
+  "languageCode": "en"
+}

--- a/Authors/framinosona.json
+++ b/Authors/framinosona.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Francois",
+  "lastName": "Raminosona",
+  "stateOrRegion": "Norway",
+  "emailAddress": "framinosona@hotmail.fr",
+  "tagOrBio": "Passionate Xamarin/Microsoft technologies developer",
+  "webSite": "https://blog.francois.raminosona.com/",
+  "feedUris": [
+    "https://blog.francois.raminosona.com/tag/xamarin/rss/"
+  ],
+  "twitterHandle": "framinosona",
+  "gravatarHash": "b3b91b8d4bd1e716982eef6e5228c92f",
+  "githubHandle": "framinosona",
+  "position": {
+    "lat": 58.9720089,
+    "lon": 5.7363974
+  },
+  "languageCode": "en"
+}

--- a/Authors/gonemobilecast.json
+++ b/Authors/gonemobilecast.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Gone",
+  "lastName": "Mobile",
+  "stateOrRegion": "Internet",
+  "emailAddress": "hello@gonemobile.io",
+  "tagOrBio": "is a development podcast focused on mobile development hosted by Jon Dick and Greg Shackles.",
+  "webSite": "http://gonemobile.io",
+  "feedUris": [
+    "https://feed.gonemobile.io/"
+  ],
+  "twitterHandle": "gonemobilecast",
+  "position": {
+    "lat": 51.253775,
+    "lon": -85.323214
+  },
+  "gravatarHash": "cb611c5ecd9a53b2af53a9d50d83c3c5",
+  "githubHandle": "",
+  "languageCode": "en"
+}

--- a/Authors/gptucci.json
+++ b/Authors/gptucci.json
@@ -1,0 +1,19 @@
+{
+  "webSite": "https://www.informaticapressapochista.com/it",
+  "firstName": "Giampaolo",
+  "lastName": "Tucci",
+  "stateOrRegion": "Italia",
+  "emailAddress": "g.tucci@informaticapressapochista.com",
+  "tagOrBio": "L'IT come non l'avete mai letta",
+  "gravatarHash": "a8846caf48c8ccc9850ff201c1e2ad1d",
+  "feedUris": [
+    "https://www.informaticapressapochista.com/it/?format=feed&type=rss"
+  ],
+  "twitterHandle": "GiampaoloTUCCI",
+  "githubHandle": "gptucci",
+  "position": {
+    "lat": 44.40138,
+    "lon": 8.93419
+  },
+  "languageCode": "it"
+}

--- a/Authors/gshackles.json
+++ b/Authors/gshackles.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Greg",
+  "lastName": "Shackles",
+  "tagOrBio": "knows a thing (or two) about mobile testing",
+  "emailAddress": "greg@gregshackles.com",
+  "twitterHandle": "gshackles",
+  "gravatarHash": "6d7b45031bf22823060849d494343a8c",
+  "stateOrRegion": "New York, NY",
+  "webSite": "https://gregshackles.com",
+  "feedUris": [
+    "https://gregshackles.com/rss/"
+  ],
+  "githubHandle": "gshackles",
+  "position": {
+    "lat": 40.712784,
+    "lon": -74.005941
+  },
+  "languageCode": "en"
+}

--- a/Authors/hnabbasi.json
+++ b/Authors/hnabbasi.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Hussain",
+  "lastName": "Abbasi",
+  "stateOrRegion": "Houston, Texas",
+  "emailAddress": "hnabbasi@outlook.com",
+  "tagOrBio": "is a Blogger, Mobile Architect, and founder of intelliAbb.com. More at HussainAbbasi.com",
+  "webSite": "https://www.intelliabb.com/",
+  "twitterHandle": "HussainNAbbasi",
+  "githubHandle": "hnabbasi",
+  "gravatarHash": "6f415af725ae2d6b5b912a7e93b105b9",
+  "feedUris": [
+    "https://www.intelliabb.com/feed"
+  ],
+  "position": {
+    "lat": 29.7656,
+    "lon": -95.3681
+  },
+  "languageCode": "en"
+}

--- a/Authors/ionixjunior.json
+++ b/Authors/ionixjunior.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Ione",
+  "lastName": "Souza Junior",
+  "tagOrBio": "",
+  "stateOrRegion": "Blumenau, Brasil",
+  "emailAddress": "junior@ionixjunior.com.br",
+  "twitterHandle": "ionixjunior",
+  "githubHandle": "ionixjunior",
+  "gravatarHash": "790726f5b5613d61926dea2e2efd4da1",
+  "position": {
+    "lat": -26.914236,
+    "lon": -49.068776
+  },
+  "webSite": "https://www.ionixjunior.com.br",
+  "feedUris": [
+    "https://www.ionixjunior.com.br/rss"
+  ],
+  "languageCode": "pt"
+}

--- a/Authors/jamesmontemagno.json
+++ b/Authors/jamesmontemagno.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "James",
+  "lastName": "Montemagno",
+  "stateOrRegion": "Seattle, WA",
+  "emailAddress": "",
+  "tagOrBio": "is a Principal Program Manager for Mobile Developer Tools",
+  "webSite": "https://montemagno.com",
+  "feedUris": [
+    "https://montemagno.com/rss"
+  ],
+  "twitterHandle": "JamesMontemagno",
+  "gravatarHash": "5df4d86308e585c879c19e5f909d8bfe",
+  "githubHandle": "jamesmontemagno",
+  "position": {
+    "lat": 47.654177,
+    "lon": -122.35
+  },
+  "languageCode": "en"
+}

--- a/Authors/jesulink2514.json
+++ b/Authors/jesulink2514.json
@@ -1,0 +1,20 @@
+{
+  "firstName": "Jesús",
+  "lastName": "Angulo",
+  "stateOrRegion": "Lima",
+  "emailAddress": "jesus.angulo@outlook.com",
+  "tagOrBio": "Microsoft MVP | Certified Xamarin Mobile Developer",
+  "webSite": "https://somostechies.com",
+  "twitterHandle": "jesulink2514",
+  "githubHandle": "jesulink2514",
+  "gravatarHash": "63359672e0ecb75e7ed261a358bf0478",
+  "feedUris": [
+    "https://somostechies.com/rss/",
+    "https://www.youtube.com/feeds/videos.xml?channel_id=UCnqaA_ArZIT0nytKMAiurzw"
+  ],
+  "position": {
+    "lat": -12.0896427,
+    "lon": -77.0060778
+  },
+  "languageCode": "es"
+}

--- a/Authors/jfversluis.json
+++ b/Authors/jfversluis.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Gerald",
+  "lastName": "Versluis",
+  "stateOrRegion": "The Netherlands",
+  "emailAddress": "gerald@verslu.is",
+  "tagOrBio": "Software Engineer at Microsoft on the Xamarin.Forms team",
+  "webSite": "https://blog.verslu.is/",
+  "feedUris": [
+    "https://blog.verslu.is/feed/"
+  ],
+  "twitterHandle": "jfversluis",
+  "gravatarHash": "f9d4d4211d7956ce3e07e83df0889731",
+  "githubHandle": "jfversluis",
+  "position": {
+    "lat": 50.889039,
+    "lon": 5.853717
+  },
+  "languageCode": "en"
+}

--- a/Authors/jgiacomini.json
+++ b/Authors/jgiacomini.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Jérôme",
+  "lastName": "Giacomini",
+  "stateOrRegion": "Paris, France",
+  "emailAddress": "jerome.giacomini@gmail.com",
+  "tagOrBio": "is a Xamarin Enthusiast, co-author of a book on Xamarin",
+  "webSite": "https://jeromegiacomini.net/Blog/",
+  "twitterHandle": "jeromegiacomini",
+  "githubHandle": "jgiacomini",
+  "gravatarHash": "95e63961669a22586a1236fd6a7a494d",
+  "feedUris": [
+    "https://jeromegiacomini.net/Blog/feed/"
+  ],
+  "position": {
+    "lat": 48.8704842,
+    "lon": 2.3449646
+  },
+  "languageCode": "fr"
+}

--- a/Authors/jimbobbennett.json
+++ b/Authors/jimbobbennett.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Jim",
+  "lastName": "Bennett",
+  "tagOrBio": "is the author of Xamarin in Action and a all-round nice guy",
+  "stateOrRegion": "Auckland, New Zealand",
+  "emailAddress": "jim@jimbobbennett.io",
+  "twitterHandle": "jimbobbennett",
+  "webSite": "https://jimbobbennett.io/",
+  "feedUris": [
+    "https://www.jimbobbennett.io/rss"
+  ],
+  "gravatarHash": "",
+  "githubHandle": "",
+  "position": {
+    "lat": -36.84846,
+    "lon": 174.763332
+  },
+  "languageCode": "en"
+}

--- a/Authors/johnthiriet.json
+++ b/Authors/johnthiriet.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "John",
+  "lastName": "Thiriet",
+  "stateOrRegion": "Paris, France",
+  "emailAddress": "johnthiriet@protonmail.com",
+  "tagOrBio": "is a Mobility Technical Manager, Trainer, Microsoft MVP, Xamarin MVP",
+  "webSite": "https://johnthiriet.com/",
+  "feedUris": [
+    "https://johnthiriet.com/feed.xml"
+  ],
+  "twitterHandle": "johnthiriet",
+  "gravatarHash": "ed92222c19a155a929d9f2c12d39c3f4",
+  "githubHandle": "johnthiriet",
+  "position": {
+    "lat": 48.875485,
+    "lon": 2.311039
+  },
+  "languageCode": "en"
+}

--- a/Authors/jssuthahar.json
+++ b/Authors/jssuthahar.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Suthahar",
+  "lastName": "Jegatheesan",
+  "tagOrBio": "insatiable desire to keep learning keeps the dynamic blogger. I take keen interest in sharing my knowledge and solving my readers’ technology-related problems.",
+  "emailAddress": "",
+  "twitterHandle": "jssuthahar",
+  "gravatarHash": "2a34ebf4e9c4dca84eb7feee7217568f",
+  "stateOrRegion": "Bangalore, India",
+  "webSite": "https://www.msdevbuild.com/",
+  "position": {
+    "lat": 12.971599,
+    "lon": 77.594563
+  },
+  "feedUris": [
+    "https://www.msdevbuild.com/feeds/posts/default"
+  ],
+  "githubHandle": "jssuthahar",
+  "languageCode": "en"
+}

--- a/Authors/jsuarezruiz.json
+++ b/Authors/jsuarezruiz.json
@@ -1,0 +1,19 @@
+{
+  "feedUris": [
+    "https://javiersuarezruiz.wordpress.com/feed/"
+  ],
+  "firstName": "Javier",
+  "lastName": "Suarez",
+  "stateOrRegion": "Seville, Spain",
+  "emailAddress": "javiersuarezruiz@hotmail.com",
+  "tagOrBio": "is a passionate software developer from Spain who enjoys learning, talk and help others",
+  "webSite": "https://javiersuarezruiz.wordpress.com",
+  "twitterHandle": "jsuarezruiz",
+  "gravatarHash": "",
+  "position": {
+    "lat": 37.389092,
+    "lon": -5.984459
+  },
+  "githubHandle": "jsuarezruiz",
+  "languageCode": "es"
+}

--- a/Authors/jtaubensee.json
+++ b/Authors/jtaubensee.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "John",
+  "lastName": "Taubensee",
+  "stateOrRegion": "Chicago, IL",
+  "emailAddress": "",
+  "tagOrBio": "is a developer focused on Microsoft technologies. Microsoft Azure alumni",
+  "webSite": "https://taubensee.net",
+  "feedUris": [
+    "https://taubensee.net/rss"
+  ],
+  "twitterHandle": "jtaubensee",
+  "gravatarHash": "151bc535ca1581cb451eb4df1672b018",
+  "githubHandle": "jtaubensee",
+  "position": {
+    "lat": 41.8778143,
+    "lon": -87.6349955
+  },
+  "languageCode": "en"
+}

--- a/Authors/kent_boogaart.json
+++ b/Authors/kent_boogaart.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Kent",
+  "lastName": "Boogaart",
+  "stateOrRegion": "Australia",
+  "emailAddress": "kent.boogaart@gmail.com",
+  "tagOrBio": "is a freelance software engineer working mainly in the mobile space",
+  "webSite": "https://kent-boogaart.com/",
+  "feedUris": [
+    "https://kent-boogaart.com/atom.xml"
+  ],
+  "twitterHandle": "kent_boogaart",
+  "gravatarHash": "",
+  "githubHandle": "",
+  "position": {
+    "lat": -35.0004451,
+    "lon": 138.3309978
+  },
+  "languageCode": "en"
+}

--- a/Authors/kphillpotts.json
+++ b/Authors/kphillpotts.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Kym",
+  "lastName": "Phillpotts",
+  "tagOrBio": "is one of the Xamarin University instructors",
+  "stateOrRegion": "Melbourne, Australia",
+  "emailAddress": "kphillpotts@gmail.com",
+  "twitterHandle": "kphillpotts",
+  "gravatarHash": "3218e66502c6f0836dfd0f02f210ba0b",
+  "webSite": "https://kymphillpotts.com/",
+  "feedUris": [
+    "https://kymphillpotts.com/feed"
+  ],
+  "githubHandle": "kphillpotts",
+  "position": {
+    "lat": -37.813628,
+    "lon": 144.963058
+  },
+  "languageCode": "en"
+}

--- a/Authors/kwlothrop.json
+++ b/Authors/kwlothrop.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Kerry W.",
+  "lastName": "Lothrop",
+  "tagOrBio": "",
+  "stateOrRegion": "Frankfurt, Germany",
+  "emailAddress": "",
+  "twitterHandle": "kwlothrop",
+  "webSite": "https://kerry.lothrop.de/",
+  "feedUris": [
+    "https://kerry.lothrop.de/en/feed/"
+  ],
+  "gravatarHash": "250241b2800a1de895a75ce039bcfef4",
+  "githubHandle": "",
+  "position": {
+    "lat": 50.1307615,
+    "lon": 8.568736
+  },
+  "languageCode": "en"
+}

--- a/Authors/logeshpalani98.json
+++ b/Authors/logeshpalani98.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Logesh",
+  "lastName": "Palani",
+  "stateOrRegion": "Thiruvannamalai,Tamil Nadu,  India",
+  "emailAddress": "logesh.01@hotmail.com",
+  "tagOrBio": "Keep Learning,.. and Keep Practicing,...",
+  "webSite": "https://logeshpalani.blogspot.com/",
+  "twitterHandle": "logeshpalani98",
+  "githubHandle": "logeshpalani98",
+  "gravatarHash": "14fd9ec21509b468c84abbed2e47384e",
+  "feedUris": [
+    "https://logeshpalani.blogspot.com/feeds/posts/default"
+  ],
+  "position": {
+    "lat": 12.527056,
+    "lon": 79.098382
+  },
+  "languageCode": "en"
+}

--- a/Authors/luismts.json
+++ b/Authors/luismts.json
@@ -1,0 +1,20 @@
+{
+  "firstName": "Luis",
+  "lastName": "Matos",
+  "stateOrRegion": "Dominican Republic",
+  "twitterHandle": "luismatosluna",
+  "emailAddress": "hello@luismts.com",
+  "tagOrBio": "Software Engineer, Entrepreneur",
+  "gravatarHash": "ac9ac28f6b1e05a310d622b37e8bc4be",
+  "webSite": "https://www.luismts.com/",
+  "feedUris": [
+    "https://www.luismts.com/feed/",
+    "https://www.luismts.com/es/feed/"
+  ],
+  "githubHandle": "luismts",
+  "position": {
+    "lat": 18.4900563,
+    "lon": -69.8962411
+  },
+  "languageCode": "en"
+}

--- a/Authors/mallibone.json
+++ b/Authors/mallibone.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Mark",
+  "lastName": "Allibone",
+  "stateOrRegion": "Zurich, Switzerland",
+  "emailAddress": "",
+  "tagOrBio": "is a Microsoft MVP who blogs, talks, coaches and develops all around mobile development.",
+  "webSite": "https://mallibone.com",
+  "twitterHandle": "mallibone",
+  "githubHandle": "mallibone",
+  "gravatarHash": "4fa14971da4fafb96830960bc7c6733d",
+  "feedUris": [
+    "https://mallibone.com/feed/"
+  ],
+  "position": {
+    "lat": 47.5056381,
+    "lon": 8.7241297
+  },
+  "languageCode": "en"
+}

--- a/Authors/marcofolio.json
+++ b/Authors/marcofolio.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Marco",
+  "lastName": "Kuiper",
+  "tagOrBio": "is a Code monkey, incurably optimistic, loves great design and passionate about Xamarin.",
+  "stateOrRegion": "The Netherlands",
+  "emailAddress": "",
+  "twitterHandle": "marcofolio",
+  "gravatarHash": "5982941cf85cecc8254ec2a4f1c812ff",
+  "githubHandle": "marcofolio",
+  "position": {
+    "lat": 51.987642,
+    "lon": 5.904598
+  },
+  "webSite": "https://www.marcofolio.net/",
+  "feedUris": [
+    "https://feeds2.feedburner.com/marcofolio"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/marcusts.json
+++ b/Authors/marcusts.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Stephen",
+  "lastName": "Marcus",
+  "stateOrRegion": "Orange County, California",
+  "emailAddress": "marcus@marcusts.com",
+  "tagOrBio": "Certified Xamarin mobile app developer",
+  "webSite": "https://www.marcusts.com",
+  "feedUris": [
+    "https://www.marcusts.com/category/Xamarin/feed/"
+  ],
+  "twitterHandle": "",
+  "gravatarHash": "a64074b2ab0ac9b5a27379670b259d6d",
+  "githubHandle": "marcusts",
+  "position": {
+    "lat": 33.6423,
+    "lon": -117.6977
+  },
+  "languageCode": "en"
+}

--- a/Authors/markolazic88.json
+++ b/Authors/markolazic88.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Marko",
+  "lastName": "Lazić",
+  "tagOrBio": "Software engineer, tech enthusiast, passionate traveler. 4+ years of active development in Xamarin.Forms",
+  "stateOrRegion": "Belgrade, Serbia",
+  "emailAddress": "marko.lazic88@gmail.com",
+  "twitterHandle": "markolazic88",
+  "gravatarHash": "5645586a7d29654e9b296b1409107014",
+  "webSite": "https://markolazic.com/",
+  "feedUris": [
+    "https://markolazic.com/feed/"
+  ],
+  "githubHandle": "markolazic88",
+  "position": {
+    "lat": 44.7866,
+    "lon": 20.4489
+  },
+  "languageCode": "en"
+}

--- a/Authors/martijn00.json
+++ b/Authors/martijn00.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Martijn",
+  "lastName": "van Dijk",
+  "stateOrRegion": "Amsterdam, Netherlands",
+  "emailAddress": "mhvdijk@gmail.com",
+  "tagOrBio": "is working at Baseflow.com on Apps and MvvmCross",
+  "webSite": "https://medium.com/@martijn00",
+  "feedUris": [
+    "https://medium.com/feed/@martijn00"
+  ],
+  "twitterHandle": "mhvdijk",
+  "gravatarHash": "22155f520ab611cf04f76762556ca3f5",
+  "githubHandle": "martijn00",
+  "position": {
+    "lat": 52.370216,
+    "lon": 4.895168
+  },
+  "languageCode": "en"
+}

--- a/Authors/mattleibow.json
+++ b/Authors/mattleibow.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Matthew",
+  "lastName": "Leibowitz",
+  "tagOrBio": "An all-round software guy. I live and breathe C# and .NET on any platform.",
+  "emailAddress": "mattleibow@live.com",
+  "twitterHandle": "mattleibow",
+  "githubHandle": "mattleibow",
+  "gravatarHash": "365da45bdc71334831f228aff805738f",
+  "stateOrRegion": "Cape Town, South Africa",
+  "position": {
+    "lat": -34.02231,
+    "lon": 18.46716
+  },
+  "webSite": "https://dotnetdevaddict.co.za",
+  "feedUris": [
+    "https://dotnetdevaddict.co.za/feed/"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/mfractor.json
+++ b/Authors/mfractor.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "MFractor",
+  "lastName": "",
+  "stateOrRegion": "Brisbane, Australia",
+  "emailAddress": "matthew@mfractor.com",
+  "tagOrBio": "is a powerful productivity tool for Xamarin Developers.",
+  "webSite": "https://www.mfractor.com/",
+  "twitterHandle": "mfractor",
+  "githubHandle": "mfractor",
+  "gravatarHash": "35bac056166a67222ddcd48b57113a32",
+  "feedUris": [
+    "https://www.mfractor.com/blogs/news.atom"
+  ],
+  "position": {
+    "lat": -27.470125,
+    "lon": 153.021072
+  },
+  "languageCode": "en"
+}

--- a/Authors/mike-grant.json
+++ b/Authors/mike-grant.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Mike",
+  "lastName": "Grant",
+  "stateOrRegion": "Leicestershire, England",
+  "emailAddress": "",
+  "tagOrBio": "Software Engineer",
+  "webSite": "https://www.mikegrant.org.uk",
+  "gravatarHash": "06c34ad3fb10ef6786a043c4522b6a5b",
+  "feedUris": [
+    "https://mikegrant.org.uk/feeds/Xamarin.Forms.xml"
+  ],
+  "twitterHandle": "mike_grant_",
+  "githubHandle": "mike-grant",
+  "position": {
+    "lat": 52.663878,
+    "lon": -1.3052377
+  },
+  "languageCode": "en"
+}

--- a/Authors/mindofai.json
+++ b/Authors/mindofai.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Bryan Anthony",
+  "lastName": "Garcia",
+  "stateOrRegion": "Manila, Philippines",
+  "githubHandle": "mindofai",
+  "twitterHandle": "mindofai",
+  "emailAddress": "bryananthonygarcia@live.com",
+  "tagOrBio": "Mobile .NET Developer who enjoys learning and writing about Mobile .NET stuff and has passion for football. Co-leads Mobile .NET Developers - Philippines",
+  "gravatarHash": "29e1cdab06c48322805220e33556c20c",
+  "webSite": "https://mindofai.github.io/",
+  "position": {
+    "lat": 14.668896,
+    "lon": 120.947204
+  },
+  "feedUris": [
+    "https://mindofai.github.io/feed.xml"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/mkieres.json
+++ b/Authors/mkieres.json
@@ -1,0 +1,19 @@
+{
+  "emailAddress": "mikolaj.kieres@progrunning.net",
+  "languageCode": "en",
+  "feedUris": [
+    "https://progrunning.net/rss/"
+  ],
+  "firstName": "Mikolaj",
+  "githubHandle": "mkieres",
+  "gravatarHash": "",
+  "lastName": "Kieres",
+  "position": {
+    "lat": -33.826623,
+    "lon": 151.195031
+  },
+  "tagOrBio": "Mobile development adventurer",
+  "stateOrRegion": "Sydney, Australia",
+  "twitterHandle": "mikolajkieres",
+  "webSite": "https://progrunning.net"
+}

--- a/Authors/msiccdev.json
+++ b/Authors/msiccdev.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Marco",
+  "lastName": "Siccardi",
+  "tagOrBio": "cross platform developer, writing software for Desktop, Mobiles and IOT",
+  "stateOrRegion": "Switzerland",
+  "emailAddress": "msiccdev@hotmail.com",
+  "twitterHandle": "msicc",
+  "gravatarHash": "67aaa7c3b6357dbccc1167a70b0c73e3",
+  "githubHandle": "msiccdev",
+  "position": {
+    "lat": 47.4683,
+    "lon": 8.75727
+  },
+  "webSite": "https://msicc.net/category/devstories/xamarin/",
+  "feedUris": [
+    "https://msicc.net/category/devstories/xamarin/feed/"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/nickrandolph.json
+++ b/Authors/nickrandolph.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Nick",
+  "lastName": "Randolph",
+  "stateOrRegion": "Sydney, Australia",
+  "emailAddress": "nick@builttoroam.com",
+  "tagOrBio": "Microsoft MVP and maintainer of @MvvmCross. Co-founder, Tech Lead at Built to Roam (@btroam), special forces in cross platform app and cloud solutions.",
+  "webSite": "https://builttoroam.com",
+  "feedUris": [
+    "https://nicksnettravels.builttoroam.com/syndication.axd"
+  ],
+  "twitterHandle": "thenickrandolph",
+  "gravatarHash": "",
+  "githubHandle": "nickrandolph",
+  "position": {
+    "lat": -33.839559,
+    "lon": 151.2112434
+  },
+  "languageCode": "en"
+}

--- a/Authors/nigelferrissey.json
+++ b/Authors/nigelferrissey.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Nigel",
+  "lastName": "Ferrissey",
+  "tagOrBio": "Mobile and front-end developer, Xamarin specialist",
+  "emailAddress": "n_ferrissey@hotmail.com",
+  "twitterHandle": "nferrissey",
+  "gravatarHash": "106ec2de3e2ea4e88e9fc431974f5d53",
+  "stateOrRegion": "Brisbane, Australia",
+  "webSite": "https://xamarininsider.com",
+  "feedUris": [
+    "https://xamarininsider.com/rss/"
+  ],
+  "githubHandle": "nigelferrissey",
+  "position": {
+    "lat": -27.469657,
+    "lon": 153.025241
+  },
+  "languageCode": "en"
+}

--- a/Authors/officialdoniald.json
+++ b/Authors/officialdoniald.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Bence",
+  "lastName": "Lenart",
+  "tagOrBio": "Xamarin developer and blogger.",
+  "stateOrRegion": "Szeged, Hungary",
+  "emailAddress": "bence960206@gmail.com",
+  "webSite": "ttps://officialdoniald.com",
+  "feedUris": [
+    "https://officialdoniald.com/feed"
+  ],
+  "twitterHandle": "officialdoniald",
+  "gravatarHash": "4e467fcdbb65da5080d215bf303c442a",
+  "githubHandle": "officialdoniald",
+  "position": {
+    "lat": 46.231222,
+    "lon": 20.119167
+  },
+  "languageCode": "en"
+}

--- a/Authors/peterfoot.json
+++ b/Authors/peterfoot.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Peter",
+  "lastName": "Foot",
+  "stateOrRegion": "United Kingdom",
+  "emailAddress": "peter@peterfoot.net",
+  "twitterHandle": "peterfoot",
+  "webSite": "https://inthehand.com/blog/",
+  "feedUris": [
+    "https://inthehand.com/category/xamarin/feed/"
+  ],
+  "gravatarHash": "fa15aeeccc4b23e8a4677aeacb65b7bb",
+  "tagOrBio": "develops Xamarin and Windows applications at In The Hand Ltd",
+  "githubHandle": "peterfoot",
+  "position": {
+    "lat": 52.76872,
+    "lon": -2.37825
+  },
+  "languageCode": "en"
+}

--- a/Authors/ramonesteban78.json
+++ b/Authors/ramonesteban78.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Ramon",
+  "lastName": "Esteban",
+  "tagOrBio": "Freelance Xamarin developer",
+  "stateOrRegion": "Malaga, Spain",
+  "emailAddress": "wantedforcode@outlook.com",
+  "twitterHandle": "ramonesteban78",
+  "gravatarHash": "2fc49c3e9095aece416ad4e147fa1452",
+  "githubHandle": "ramonesteban78",
+  "position": {
+    "lat": 36.5126395,
+    "lon": -4.6483388
+  },
+  "webSite": "https://ramonesteban78.github.io/",
+  "feedUris": [
+    "https://ramonesteban78.github.io/feed.xml"
+  ],
+  "languageCode": "es"
+}

--- a/Authors/rdavisau.json
+++ b/Authors/rdavisau.json
@@ -1,0 +1,19 @@
+{
+  "feedUris": [
+    "https://ryandavis.io/rss/"
+  ],
+  "firstName": "Ryan",
+  "lastName": "Davis",
+  "stateOrRegion": "Brisbane, Australia",
+  "emailAddress": "ryandavis.au@gmail.com",
+  "tagOrBio": "knows how to 🎉",
+  "webSite": "https://ryandavis.io",
+  "twitterHandle": "rdavis_au",
+  "githubHandle": "rdavisau",
+  "gravatarHash": "d351762ec451e252b20ff860dfcded91d351762ec451e252b20ff860dfcded91",
+  "position": {
+    "lat": -27.469771,
+    "lon": 153.025124
+  },
+  "languageCode": "en"
+}

--- a/Authors/rdelrosario.json
+++ b/Authors/rdelrosario.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Rendy",
+  "lastName": "Del Rosario",
+  "tagOrBio": "is a senior software developer with a passion for mobile development using Xamarin platform",
+  "stateOrRegion": "Dominican Republic",
+  "emailAddress": "rendy@crossgeeks.com",
+  "twitterHandle": "rdelrosario",
+  "gravatarHash": "4bece0ce1c33e65177110bcb95688c68",
+  "githubHandle": "rdelrosario",
+  "position": {
+    "lat": 18.486058,
+    "lon": -69.931212
+  },
+  "webSite": "https://xamboy.com/",
+  "feedUris": [
+    "https://xamboy.com/rss"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/redth.json
+++ b/Authors/redth.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Jon",
+  "lastName": "Dick",
+  "tagOrBio": "",
+  "emailAddress": "jondick@gmail.com",
+  "twitterHandle": "redth",
+  "gravatarHash": "ad73e52d7e4d89e904e7c4cfd91fc2b9",
+  "stateOrRegion": "Ontario, Canada",
+  "webSite": "https://redth.codes",
+  "feedUris": [
+    "https://redth.codes/feed/"
+  ],
+  "githubHandle": "redth",
+  "position": {
+    "lat": 51.253775,
+    "lon": -85.323214
+  },
+  "languageCode": "en"
+}

--- a/Authors/ricardoprestes.json
+++ b/Authors/ricardoprestes.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Ricardo",
+  "lastName": "Prestes",
+  "stateOrRegion": "Cornélio Procópio, Brasil",
+  "emailAddress": "ricardo.logan@hotmail.com",
+  "tagOrBio": "Tech lead mobile developer, Burger Monkeys Co-founder",
+  "webSite": "https://oficinadologan.wordpress.com/",
+  "twitterHandle": "ricardo_prestes",
+  "githubHandle": "ricardoprestes",
+  "gravatarHash": "9802e38d5bd2cd85db8b0720d5feed29",
+  "feedUris": [
+    "https://oficinadologan.wordpress.com/rss"
+  ],
+  "position": {
+    "lat": -23.194571,
+    "lon": -50.7795215
+  },
+  "languageCode": "pt"
+}

--- a/Authors/rid00z.json
+++ b/Authors/rid00z.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Michael",
+  "lastName": "Ridland",
+  "stateOrRegion": "Sydney, Australia",
+  "emailAddress": "michael@xam-consulting.com",
+  "tagOrBio": "Xamarin Contractor/Consultant | Founder XAM Consulting (xam-consulting.com) | Creator of FreshMvvm",
+  "webSite": "https://michaelridland.com",
+  "feedUris": [
+    "https://michaelridland.com/feed/"
+  ],
+  "twitterHandle": "rid00z",
+  "gravatarHash": "3c07e56045d18f4f290eb4983031309d",
+  "githubHandle": "rid00z",
+  "position": {
+    "lat": -25.348875,
+    "lon": 131.035
+  },
+  "languageCode": "en"
+}

--- a/Authors/robintschroeder.json
+++ b/Authors/robintschroeder.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Robin",
+  "lastName": "Schroeder",
+  "tagOrBio": "Xamarin.Forms/UWP Software Consultant at MSCTek",
+  "stateOrRegion": "Illinois",
+  "emailAddress": "robin@msctek.com",
+  "twitterHandle": "RTSchroeder",
+  "gravatarHash": "1754cd9eee726fd3a5252a4718cbf108",
+  "githubHandle": "robintschroeder",
+  "position": {
+    "lat": 41.9136926,
+    "lon": -88.3148351
+  },
+  "webSite": "https://msctek.com/",
+  "feedUris": [
+    "https://www.msctek.com/feed/"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/roubachof.json
+++ b/Authors/roubachof.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Jean-Marie",
+  "lastName": "Alfonsi",
+  "tagOrBio": "is a singing software engineer who travels at the speed light and wanna make a supersonic man out of you.",
+  "stateOrRegion": "Paris, France",
+  "emailAddress": "jm.alfonsi@gmail.com",
+  "twitterHandle": "Piskariov",
+  "gravatarHash": "2a30d8bc59e2ccb6e83bb498d519394a",
+  "webSite": "https://www.sharpnado.com/",
+  "feedUris": [
+    "https://www.sharpnado.com/rss/"
+  ],
+  "githubHandle": "roubachof",
+  "position": {
+    "lat": 48.8588377,
+    "lon": 2.2770206
+  },
+  "languageCode": "en"
+}

--- a/Authors/saamerm.json
+++ b/Authors/saamerm.json
@@ -1,0 +1,19 @@
+{
+  "feedUris": [
+    "https://medium.com/feed/@prototypemakers"
+  ],
+  "firstName": "Saamer",
+  "lastName": "Mansoor",
+  "stateOrRegion": "Toronto, Canada",
+  "emailAddress": "i@saamer.me",
+  "tagOrBio": "Top 5% Xamarin StackOverflow, Freelancer, Trainer",
+  "webSite": "https://medium.com/@prototypemakers",
+  "twitterHandle": "saamerm",
+  "githubHandle": "saamerm",
+  "gravatarHash": "66887acb0b76f2d3059255a1c53a3b22",
+  "position": {
+    "lat": 43.639728,
+    "lon": -79.380099
+  },
+  "languageCode": "en"
+}

--- a/Authors/sact1909.json
+++ b/Authors/sact1909.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Steven",
+  "lastName": "Checo",
+  "stateOrRegion": "United States",
+  "emailAddress": "steven.checo.19@gmail.com",
+  "tagOrBio": "is a C# ASP.Net and Xamarin Developer, I'd preferd back-end but I get along with the Front-End, I love help others with code and build new things with friends, I ♥ C#",
+  "webSite": "https://checox.com",
+  "twitterHandle": "steven1909",
+  "githubHandle": "sact1909",
+  "gravatarHash": "47ad7178de588bb9a0b5922a5c1364c8",
+  "feedUris": [
+    "https://checox.com/feed/"
+  ],
+  "position": {
+    "lat": 40.837222,
+    "lon": -73.886111
+  },
+  "languageCode": "en"
+}

--- a/Authors/samirgcofficial.json
+++ b/Authors/samirgcofficial.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Samir",
+  "lastName": "GC",
+  "tagOrBio": ".net lover, xamarin mobile developer | XamarinGuy Show Host | Trainer | Instructor",
+  "stateOrRegion": "Kathmandu/Nepal",
+  "emailAddress": "samirgcofficial@gmail.com",
+  "twitterHandle": "xamaringuy",
+  "githubHandle": "samirgcofficial",
+  "position": {
+    "lat": 27.700769,
+    "lon": 85.30014
+  },
+  "webSite": "https://xamaringuyshow.com/",
+  "feedUris": [
+    "https://xamaringuyshow.com/feed/"
+  ],
+  "gravatarHash": "4b0b695b7711b0184ab2049e33f2cfd7",
+  "languageCode": "en"
+}

--- a/Authors/shirshov.json
+++ b/Authors/shirshov.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Alex",
+  "lastName": "Shirshov",
+  "stateOrRegion": "Sydney, Australia",
+  "emailAddress": "shirshov@gmail.com",
+  "tagOrBio": "Software Craftsman",
+  "webSite": "https://omnitalented.com",
+  "twitterHandle": "omnitalented",
+  "githubHandle": "shirshov",
+  "gravatarHash": "",
+  "position": {
+    "lat": -33.88236,
+    "lon": 151.206588
+  },
+  "languageCode": "en",
+  "feedUris": [
+    "https://omnitalented.com/rss-xamarin.xml"
+  ]
+}

--- a/Authors/smstuebe.json
+++ b/Authors/smstuebe.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Sven-Michael",
+  "lastName": "Stübe",
+  "tagOrBio": "loves the cross platform approach, develops Xamarin plugins and organizes Xamarin Pizza & Beer Meetups in Munich",
+  "stateOrRegion": "Munich, Germany",
+  "emailAddress": "",
+  "twitterHandle": "stuebe2k14",
+  "webSite": "https://smstuebe.de/",
+  "feedUris": [
+    "https://smstuebe.de/feed.xml"
+  ],
+  "githubHandle": "smstuebe",
+  "gravatarHash": "08b73d0a58fc120a8cc8dc561d83b3d6",
+  "position": {
+    "lat": 48.1373831,
+    "lon": 11.5063151
+  },
+  "languageCode": "en"
+}

--- a/Authors/sthewissen.json
+++ b/Authors/sthewissen.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Steven",
+  "lastName": "Thewissen",
+  "stateOrRegion": "The Netherlands",
+  "emailAddress": "",
+  "tagOrBio": " is a Xamarin Developer with a knack for Photoshop and a passion for soccer and cycling. He is also in love with his Xbox One",
+  "webSite": "https://www.thewissen.io/",
+  "feedUris": [
+    "https://www.thewissen.io/feed/"
+  ],
+  "twitterHandle": "devnl",
+  "gravatarHash": "9f698e6f515cb54dbda305034b6823fc",
+  "position": {
+    "lat": 50.889039,
+    "lon": 5.853717
+  },
+  "githubHandle": "sthewissen",
+  "languageCode": "en"
+}

--- a/Authors/stvansolano.json
+++ b/Authors/stvansolano.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Esteban",
+  "lastName": "Solano",
+  "stateOrRegion": "Cartago, Costa Rica",
+  "emailAddress": "stvansolano@outlook.com",
+  "tagOrBio": "is a passionate software community guy from Costa Rica who enjoys learning, talk and help others to learn C# and Xamarin",
+  "webSite": "https://stvansolano.github.io/",
+  "feedUris": [
+    "https://stvansolano.github.io/atom.xml"
+  ],
+  "twitterHandle": "stvansolano",
+  "gravatarHash": "d02d96057c4cd905d60d14549b00db0d",
+  "githubHandle": "stvansolano",
+  "position": {
+    "lat": 9.9322992,
+    "lon": -84.0815271
+  },
+  "languageCode": "es"
+}

--- a/Authors/susairajs.json
+++ b/Authors/susairajs.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Delpin",
+  "lastName": "Susai Raj",
+  "stateOrRegion": "Chennai, India",
+  "emailAddress": "susairajs@outlook.com",
+  "tagOrBio": "Code with Monkeys",
+  "webSite": "https://xamarinmonkeys.blogspot.com/",
+  "twitterHandle": "susairajs18",
+  "githubHandle": "susairajs",
+  "gravatarHash": "3408967b9598e7bb107baf15d5a15454",
+  "feedUris": [
+    "https://xamarinmonkeys.blogspot.com/feeds/posts/default"
+  ],
+  "position": {
+    "lat": 13.0783995,
+    "lon": 80.2886684
+  },
+  "languageCode": "en"
+}

--- a/Authors/syncfusion.json
+++ b/Authors/syncfusion.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Syncfusion",
+  "lastName": "",
+  "stateOrRegion": "North Carolina, USA",
+  "emailAddress": "info@syncfusion.com",
+  "tagOrBio": "Syncfusion provides the best third-party UI components for Xamarin, Xamarin.Android and Xamarin.iOS",
+  "webSite": "https://www.syncfusion.com/xamarin-ui-controls",
+  "feedUris": [
+    "https://www.syncfusion.com/blogs/feed"
+  ],
+  "twitterHandle": "Syncfusion",
+  "gravatarHash": "4291ef07481d300471113dbd4b4aabc2",
+  "githubHandle": "syncfusion",
+  "position": {
+    "lat": 35.855361,
+    "lon": -78.815751
+  },
+  "languageCode": "en"
+}

--- a/Authors/tbertuzzi.json
+++ b/Authors/tbertuzzi.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Thiago",
+  "lastName": "Bertuzzi",
+  "tagOrBio": "Web and Mobile Developer, Blogger, Speaker",
+  "stateOrRegion": "São Paulo, Brasil",
+  "emailAddress": "thiago.bertuzzi@gmail.com",
+  "twitterHandle": "tbertuzzi",
+  "githubHandle": "tbertuzzi",
+  "gravatarHash": "82d95125be475913cdc7a7fe319d0133",
+  "position": {
+    "lat": -23.5834337,
+    "lon": -46.6672048
+  },
+  "webSite": "https://medium.com/@bertuzzi/",
+  "feedUris": [
+    "https://medium.com/feed/@bertuzzi"
+  ],
+  "languageCode": "pt"
+}

--- a/Authors/telerik.json
+++ b/Authors/telerik.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Telerik",
+  "lastName": "",
+  "stateOrRegion": "Global",
+  "emailAddress": "telerikxamarinteam@progress.com",
+  "tagOrBio": "Progress Telerik UI libraries equip .NET ninjas with a full arsenal of weapons to help you create beautiful, modern and future-proof applications quickly and intuitively.",
+  "webSite": "https://www.telerik.com/",
+  "twitterHandle": "telerik",
+  "githubHandle": "telerik",
+  "gravatarHash": "",
+  "feedUris": [
+    "https://feeds.telerik.com/blogs"
+  ],
+  "position": {
+    "lat": 42.512778,
+    "lon": -71.2515
+  },
+  "languageCode": "en"
+}

--- a/Authors/trailheadtechnology.json
+++ b/Authors/trailheadtechnology.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Trailhead Technology",
+  "lastName": "",
+  "stateOrRegion": "Jenison, MI",
+  "twitterHandle": "@TrailheadTec",
+  "emailAddress": "info@trailheadtechnology.com",
+  "tagOrBio": "",
+  "gravatarHash": "0d6c200b64336790495f110332e1d7be",
+  "webSite": "https://www.trailheadtechnology.com/",
+  "feedUris": [
+    "https://trailheadtechnology.com/feed"
+  ],
+  "githubHandle": "trailheadtechnology",
+  "position": {
+    "lat": 42.921436,
+    "lon": -85.806578
+  },
+  "languageCode": "en"
+}

--- a/Authors/vulcanlee.json
+++ b/Authors/vulcanlee.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Vulcan",
+  "lastName": "Lee",
+  "stateOrRegion": "Taipei, Taiwan",
+  "twitterHandle": "vulcanlee",
+  "emailAddress": "vulcan.lee@gmail.com",
+  "tagOrBio": "Vulcan Lee is a Microsoft MVP who develops Xamarin at Doggy Ltd",
+  "gravatarHash": "f5de84ba365a15a05748624c07e70075",
+  "webSite": "https://mylabtw.blogspot.com/",
+  "feedUris": [
+    "https://mylabtw.blogspot.com/feeds/posts/default?alt=rss"
+  ],
+  "githubHandle": "vulcanlee",
+  "position": {
+    "lat": 25.043847,
+    "lon": 121.525645
+  },
+  "languageCode": "zh"
+}

--- a/Authors/willsb.json
+++ b/Authors/willsb.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "William",
+  "lastName": "Barbosa",
+  "stateOrRegion": "Santos, Brasil",
+  "twitterHandle": "willdotnet",
+  "githubHandle": "willsb",
+  "tagOrBio": "Microsoft MVP, Blogger, Speaker, Monkey Nights Co-founder/Host and MvvmCross contributor",
+  "emailAddress": "heytherewill@gmail.com",
+  "gravatarHash": "e47d219e8ee5d6dd5a44940dc26585c4",
+  "position": {
+    "lat": -23.954821,
+    "lon": -46.3247136
+  },
+  "webSite": "https://willsb.github.io",
+  "feedUris": [
+    "https://medium.com/feed/@heytherewill"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/winstongubantes.json
+++ b/Authors/winstongubantes.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Winston",
+  "lastName": "Gubantes",
+  "tagOrBio": "a Xamarin Developer at Gluon Consulting",
+  "stateOrRegion": "Davao City, Philippines",
+  "emailAddress": "winston.gubantes@gmail.com",
+  "twitterHandle": "tony_fear",
+  "gravatarHash": "9e1aea174237384361fc260b33559d05",
+  "githubHandle": "winstongubantes",
+  "position": {
+    "lat": 7.1066271,
+    "lon": 125.6294976
+  },
+  "webSite": "https://winstongubantes.blogspot.com/",
+  "feedUris": [
+    "https://winstongubantes.blogspot.com/feeds/posts/default?alt=rss"
+  ],
+  "languageCode": "es"
+}

--- a/Authors/wislon.json
+++ b/Authors/wislon.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "John",
+  "lastName": "Wilson",
+  "stateOrRegion": "Brisbane, Australia",
+  "emailAddress": "wislon@hotmail.com",
+  "tagOrBio": "Head of Mobile, Tech Lead, Xamarin Specialist",
+  "webSite": "https://blog.wislon.io/",
+  "feedUris": [
+    "https://blog.wislon.io/atom.xml"
+  ],
+  "twitterHandle": "wislon",
+  "gravatarHash": "86c9d925c04b4c79c98bfc839d949e15",
+  "githubHandle": "wislon",
+  "position": {
+    "lat": -27.3812513,
+    "lon": 152.7130138
+  },
+  "languageCode": "en"
+}

--- a/Authors/xablu.json
+++ b/Authors/xablu.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Xablu",
+  "lastName": "",
+  "stateOrRegion": "Amsterdam, the Netherlands",
+  "emailAddress": "hello@xablu.com",
+  "tagOrBio": "a 100% pure Xamarin company.",
+  "webSite": "https://www.xablu.com/",
+  "twitterHandle": "xabluhq",
+  "githubHandle": "xablu",
+  "gravatarHash": "508b1a99bb81e09c189e7487ecb69167",
+  "feedUris": [
+    "https://www.xablu.com/tag/planet-xamarin/feed/"
+  ],
+  "position": {
+    "lat": 52.3702,
+    "lon": 4.8952
+  },
+  "languageCode": "en"
+}

--- a/Authors/xamarin.json
+++ b/Authors/xamarin.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "The Xamarin",
+  "lastName": "Blog",
+  "stateOrRegion": "Internet",
+  "emailAddress": "hello@xamarin.com",
+  "tagOrBio": "is your official source for Xamarin developer news.",
+  "webSite": "https://blog.xamarin.com",
+  "feedUris": [
+    "https://devblogs.microsoft.com/xamarin/feed/"
+  ],
+  "twitterHandle": "xamarinhq",
+  "gravatarHash": "70148d964bb389d42547834e1062c886",
+  "githubHandle": "xamarin",
+  "position": {
+    "lat": 37.77493,
+    "lon": -122.419416
+  },
+  "languageCode": "en"
+}

--- a/Authors/xamarinhowto.json
+++ b/Authors/xamarinhowto.json
@@ -1,0 +1,19 @@
+{
+  "firstName": "Matt",
+  "lastName": "Crombie",
+  "tagOrBio": "Senior Xamarin Mobile Consultant/Architect",
+  "stateOrRegion": "Brisbane, Australia",
+  "emailAddress": "matt@xamarinhowto.com",
+  "twitterHandle": "xamarinhowto",
+  "gravatarHash": "3f1200c50911032b3558b7c0fc29c847",
+  "githubHandle": "xamarinhowto",
+  "position": {
+    "lat": -27.46845,
+    "lon": 153.024184
+  },
+  "webSite": "https://xamarinhowto.com/",
+  "feedUris": [
+    "https://xamarinhowto.com/feed/"
+  ],
+  "languageCode": "en"
+}

--- a/Authors/yuv4ik.json
+++ b/Authors/yuv4ik.json
@@ -1,0 +1,20 @@
+{
+  "firstName": "Evgeny",
+  "lastName": "Zborovsky",
+  "stateOrRegion": "Estonia",
+  "emailAddress": "yuv4ik@gmail.com",
+  "tagOrBio": "blogs, speaks, helps others and is an enthusiastic Xamarin developer.",
+  "webSite": "https://evgenyzborovsky.com/",
+  "feedUris": [
+    "https://evgenyzborovsky.com/tag/xamarin-forms/feed/",
+    "https://evgenyzborovsky.com/tag/xamarin/feed/"
+  ],
+  "twitterHandle": "ezborovsky",
+  "gravatarHash": "b8a0ab8445fafb38afdf26cb976df32f",
+  "githubHandle": "yuv4ik",
+  "position": {
+    "lat": 58.3750372,
+    "lon": 26.6625567
+  },
+  "languageCode": "en"
+}

--- a/PlanetXamarin.sln
+++ b/PlanetXamarin.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30517.126
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlanetXamarin", "PlanetXamarin\PlanetXamarin.csproj", "{591E633A-5665-4D84-B4B6-02B627699AC4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8FA44784-F2C3-4749-9272-38F4D8EA9398}"
+	ProjectSection(SolutionItems) = preProject
+		author-schema.json = author-schema.json
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlanetXamarinAuthors", "PlanetXamarinAuthors\PlanetXamarinAuthors.csproj", "{57C40CD9-62CF-48D2-9A5E-C4CDD1CE6082}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{591E633A-5665-4D84-B4B6-02B627699AC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{591E633A-5665-4D84-B4B6-02B627699AC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{591E633A-5665-4D84-B4B6-02B627699AC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{591E633A-5665-4D84-B4B6-02B627699AC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57C40CD9-62CF-48D2-9A5E-C4CDD1CE6082}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57C40CD9-62CF-48D2-9A5E-C4CDD1CE6082}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57C40CD9-62CF-48D2-9A5E-C4CDD1CE6082}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57C40CD9-62CF-48D2-9A5E-C4CDD1CE6082}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E14EAD9A-3E05-4B45-AFB6-E3E98BB88660}
+	EndGlobalSection
+EndGlobal

--- a/PlanetXamarin/Extensions/SyndicationItemExtensions.cs
+++ b/PlanetXamarin/Extensions/SyndicationItemExtensions.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using System.ServiceModel.Syndication;
+
+namespace PlanetXamarin.Extensions
+{
+    public static class SyndicationItemExtensions
+    {
+        public static bool ApplyDefaultFilter(this SyndicationItem item)
+        {
+            if (item == null)
+                return false;
+
+            var hasXamarinCategory = false;
+            var hasXamarinKeywords = false;
+
+            if (item.Categories.Count > 0)
+            {
+                hasXamarinCategory = item.Categories.Any(category =>
+                    category.Name.ToLowerInvariant().Contains("xamarin"));
+            }
+
+            if (item.ElementExtensions.Count > 0)
+            {
+                var element = item.ElementExtensions.FirstOrDefault(e => e.OuterName == "keywords");
+                if (element != null)
+                {
+                    var keywords = element.GetObject<string>();
+                    hasXamarinKeywords = keywords.ToLowerInvariant().Contains("xamarin");
+                }
+            }
+
+            var hasXamarinTitle = item.Title?.Text.ToLowerInvariant().Contains("xamarin") ?? false;
+
+            return hasXamarinTitle || hasXamarinCategory || hasXamarinKeywords;
+        }
+
+		public static string ToHtml(this SyndicationContent content)
+		{
+			var textSyndicationContent = content as TextSyndicationContent;
+			if (textSyndicationContent != null)
+			{
+				return textSyndicationContent.Text;
+			}
+
+			return content.ToString();
+		}
+	}
+}

--- a/PlanetXamarin/Infrastructure/CombinedFeedSource.cs
+++ b/PlanetXamarin/Infrastructure/CombinedFeedSource.cs
@@ -1,0 +1,213 @@
+using Microsoft.Extensions.Logging;
+using PlanetXamarin.Extensions;
+using PlanetXamarinAuthors.Models;
+using Polly;
+using Polly.Retry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.ServiceModel.Syndication;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace PlanetXamarin.Infrastructure
+{
+    public class CombinedFeedSource
+    {
+        private static HttpClient _httpClient;
+        private static AsyncRetryPolicy _retryPolicy;
+        private readonly IEnumerable<Author> _authors;
+        private readonly ILogger _logger;
+        private readonly string _rssFeedTitle;
+        private readonly string _rssFeedDescription;
+        private readonly string _rssFeedUrl;
+        private readonly string _rssFeedImageUrl;
+
+        public CombinedFeedSource(
+            IEnumerable<Author> authors,
+            ILogger logger,
+            string rssFeedTitle,
+            string rssFeedDescription,
+            string rssFeedUrl,
+            string rssFeedImageUrl)
+        {
+            EnsureHttpClient();
+
+            if (_retryPolicy == null)
+            {
+                // retry policy with max 2 retries, delay by x*x^1.2 where x is retry attempt
+                // this will ensure we don't retry too quickly
+                _retryPolicy = Policy.Handle<FeedReadFailedException>()
+                    .WaitAndRetryAsync(2, retry => TimeSpan.FromSeconds(retry * Math.Pow(1.2, retry)));
+            }
+
+            _authors = authors;
+            _logger = logger;
+            _rssFeedTitle = rssFeedTitle;
+            _rssFeedDescription = rssFeedDescription;
+            _rssFeedUrl = rssFeedUrl;
+            _rssFeedImageUrl = rssFeedImageUrl;
+        }
+
+        private void EnsureHttpClient()
+        {
+            if (_httpClient == null)
+            {
+                _httpClient = new HttpClient();
+                _httpClient.DefaultRequestHeaders.UserAgent.Add(
+                    new ProductInfoHeaderValue("PlanetXamarin", $"{GetType().Assembly.GetName().Version}"));
+                _httpClient.Timeout = TimeSpan.FromSeconds(15);
+
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls13;
+            }
+        }
+
+        public async Task<SyndicationFeed> LoadFeed(int? numberOfItems, string languageCode = "mixed")
+        {
+            IEnumerable<Author> tamarins;
+            if (languageCode == null || languageCode == "mixed") // use all tamarins
+            {
+                tamarins = _authors;
+            }
+            else
+            {
+                tamarins = _authors.Where(t => t.FeedLanguageCode == languageCode);
+            }
+
+            var feedTasks = tamarins.SelectMany(t => TryReadFeeds(t)).ToArray();
+
+            _logger?.LogInformation($"Loading feed for language: {languageCode} for {feedTasks.Length} authors");
+
+            var syndicationItems = await Task.WhenAll(feedTasks).ConfigureAwait(false);
+            var combinedFeed = GetCombinedFeed(syndicationItems.SelectMany(f => f), languageCode, tamarins, numberOfItems);
+            return combinedFeed;
+        }
+
+        private IEnumerable<Task<IEnumerable<SyndicationItem>>> TryReadFeeds(Author tamarin)
+        {
+            return tamarin.FeedUris.Select(uri => TryReadFeed(tamarin, uri.AbsoluteUri));
+        }
+
+        private async Task<IEnumerable<SyndicationItem>> TryReadFeed(Author tamarin, string feedUri)
+        {
+            try
+            {
+                return await _retryPolicy.ExecuteAsync(context => ReadFeed(feedUri), new Context(feedUri)).ConfigureAwait(false);
+            }
+            catch (FeedReadFailedException ex)
+            {
+                _logger.LogError(ex, $"{tamarin.FirstName} {tamarin.LastName}'s feed of {ex.Data["FeedUri"]} failed to load.");
+            }
+
+            return new SyndicationItem[0];
+        }
+
+        private async Task<IEnumerable<SyndicationItem>> ReadFeed(string feedUri)
+        {
+            HttpResponseMessage response;
+            try
+            {
+                _logger?.LogInformation($"Loading feed {feedUri}");
+                response = await _httpClient.GetAsync(feedUri).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                {
+                    using var feedStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    using var reader = XmlReader.Create(feedStream);
+                    var feed = SyndicationFeed.Load(reader);
+                    var filteredItems = feed.Items
+                        .Where(item => item.ApplyDefaultFilter());
+
+                    return filteredItems;
+                }
+            }
+            catch (HttpRequestException hex)
+            {
+                throw new FeedReadFailedException("Loading remote syndication feed failed", hex)
+                    .WithData("FeedUri", feedUri);
+            }
+            catch (WebException ex)
+            {
+                throw new FeedReadFailedException("Loading remote syndication feed timed out", ex)
+                    .WithData("FeedUri", feedUri);
+            }
+            catch (XmlException ex)
+            {
+                throw new FeedReadFailedException("Failed parsing remote syndication feed", ex)
+                    .WithData("FeedUri", feedUri);
+            }
+            catch (TaskCanceledException ex)
+            {
+                throw new FeedReadFailedException("Reading feed timed out", ex)
+                    .WithData("FeedUri", feedUri);
+            }
+            catch (OperationCanceledException opcex)
+            {
+                throw new FeedReadFailedException("Reading feed timed out", opcex)
+                    .WithData("FeedUri", feedUri);
+            }
+
+            throw new FeedReadFailedException("Loading remote syndication feed failed.")
+                .WithData("FeedUri", feedUri)
+                .WithData("HttpStatusCode", (int)response.StatusCode);
+        }
+
+        private SyndicationFeed GetCombinedFeed(IEnumerable<SyndicationItem> items, string languageCode, 
+            IEnumerable<Author> tamarins, int? numberOfItems)
+        {
+            DateTimeOffset GetMaxTime(SyndicationItem item)
+            {
+                return new[] { item.PublishDate.UtcDateTime, item.LastUpdatedTime.UtcDateTime }.Max();
+            }
+
+            var orderedItems = items
+                .Where(item =>
+                    GetMaxTime(item) <= DateTimeOffset.UtcNow)
+                .OrderByDescending(item => GetMaxTime(item));
+
+            var feed = new SyndicationFeed(
+                _rssFeedTitle,
+                _rssFeedDescription,
+                new Uri(_rssFeedUrl),
+                numberOfItems.HasValue ? orderedItems.Take(numberOfItems.Value) : orderedItems)
+            {
+                ImageUrl = new Uri(_rssFeedImageUrl),
+                Copyright = new TextSyndicationContent("The copyright for each post is retained by its author."),
+                Language = languageCode,
+                LastUpdatedTime = DateTimeOffset.UtcNow
+            };
+
+            foreach(var tamarin in tamarins)
+            {
+                feed.Contributors.Add(new SyndicationPerson(
+                    tamarin.EmailAddress, $"{tamarin.FirstName} {tamarin.LastName}", tamarin.WebSite.ToString()));
+            }
+
+            return feed;
+        }
+    }
+
+    public class FeedReadFailedException : Exception
+    {
+        public FeedReadFailedException(string message) 
+            : base(message)
+        {
+        }
+
+        public FeedReadFailedException(string message, Exception inner) 
+            : base(message, inner)
+        {
+        }
+    }
+
+    internal static class ExceptionExtensions
+    {
+        public static TException WithData<TException>(this TException exception, string key, object value) where TException : Exception
+        {
+            exception.Data[key] = value;
+            return exception;
+        }
+    }
+}

--- a/PlanetXamarin/LoadFeedsFunction.cs
+++ b/PlanetXamarin/LoadFeedsFunction.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.ServiceModel.Syndication;
+using System.Threading.Tasks;
+using System.Xml;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using PlanetXamarin.Infrastructure;
+using PlanetXamarinAuthors;
+
+namespace PlanetXamarin
+{
+    public static class LoadFeedsFunction
+    {
+        [FunctionName("LoadFeedsFunction")]
+        public static async Task Run(
+            [TimerTrigger("0 0 */1 * * *", RunOnStartup = true)]TimerInfo myTimer,
+            ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+
+            var rssFeedTitle = GetEnvironmentVariable("RssFeedTitle");
+            var rssFeedDescription = GetEnvironmentVariable("RssFeedDescription");
+            var rssFeedUrl = GetEnvironmentVariable("RssFeedUrl");
+            var rssFeedImageUrl = GetEnvironmentVariable("RssFeedImageUrl");
+
+            var authors = await AuthorsLoader.GetAllAuthors();
+            var languages = authors.Select(author => author.FeedLanguageCode).Distinct().ToList();
+            languages.Add("mixed");
+            var feedSource =
+                new CombinedFeedSource(
+                    authors,
+                    log,
+                    rssFeedTitle,
+                    rssFeedDescription,
+                    rssFeedUrl,
+                    rssFeedImageUrl);
+
+            var blobConnectString = GetEnvironmentVariable("FeedBlobStorage");
+            var container = new BlobContainerClient(blobConnectString, "feeds");
+            await container.CreateIfNotExistsAsync();
+            await container.SetAccessPolicyAsync(PublicAccessType.Blob);
+
+            foreach (var language in languages)
+            {
+                log.LogInformation($"Loading {language} combined author feed");
+                var feed = await feedSource.LoadFeed(null, language);
+                using var stream = await SerializeFeed(feed);
+                await UploadBlob(container, stream, language, log);
+            }
+        }
+
+        private static async Task UploadBlob(BlobContainerClient container, Stream feedStream, string language, ILogger log)
+        {
+            var feedName = $"feed.{language}.rss";
+            var blob = container.GetBlobClient(feedName);
+            await blob.UploadAsync(feedStream, overwrite: true);
+
+            log.LogInformation($"Uploaded {feedName} to {blob.Uri}");
+        }
+
+        private static async Task<Stream> SerializeFeed(SyndicationFeed feed)
+        {
+            var memoryStream = new MemoryStream();
+            using var xmlWriter = XmlWriter.Create(memoryStream, new XmlWriterSettings
+            {
+                Async = true
+            });
+
+            var rssFormatter = new Rss20FeedFormatter(feed);
+            rssFormatter.WriteTo(xmlWriter);
+            await xmlWriter.FlushAsync();
+
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            return memoryStream;
+        }
+
+        private static string GetEnvironmentVariable(string name)
+        {
+            return Environment.GetEnvironmentVariable(name, EnvironmentVariableTarget.Process);
+        }
+    }
+}

--- a/PlanetXamarin/PlanetXamarin.csproj
+++ b/PlanetXamarin/PlanetXamarin.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Polly" Version="7.2.1" />
+    <PackageReference Include="System.ServiceModel.Syndication" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PlanetXamarinAuthors\PlanetXamarinAuthors.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/PlanetXamarin/Properties/serviceDependencies.json
+++ b/PlanetXamarin/Properties/serviceDependencies.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "storage1": {
+      "type": "storage",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/PlanetXamarin/Properties/serviceDependencies.local.json
+++ b/PlanetXamarin/Properties/serviceDependencies.local.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "storage1": {
+      "type": "storage.emulator",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/PlanetXamarin/host.json
+++ b/PlanetXamarin/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingExcludedTypes": "Request",
+            "samplingSettings": {
+                "isEnabled": true
+            }
+        }
+    }
+}

--- a/PlanetXamarin/local.settings.json
+++ b/PlanetXamarin/local.settings.json
@@ -1,0 +1,12 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    "RssFeedTitle": "Planet Xamarin",
+    "RssFeedDescription": "An aggregated feed from the Xamarin community",
+    "RssFeedUrl": "https://www.planetxamarin.com/feed",
+    "RssFeedImageUrl": "https://www.planetxamarin.com/Content/Logo.png",
+    "FeedBlobStorage": ""
+  }
+}

--- a/PlanetXamarinAuthors/AuthorsLoader.cs
+++ b/PlanetXamarinAuthors/AuthorsLoader.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using PlanetXamarinAuthors.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace PlanetXamarinAuthors
+{
+    public static class AuthorsLoader
+    {
+        public static async Task<IEnumerable<Author>> GetAllAuthors()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var resourceNames = assembly.GetManifestResourceNames();
+            var authorsResourceNames = resourceNames.Where(res =>
+                res.StartsWith("PlanetXamarinAuthors", StringComparison.OrdinalIgnoreCase) &&
+                res.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
+
+            var authorsTasks = authorsResourceNames.Select(name => ReadAuthor(assembly, name));
+            var authors = await Task.WhenAll(authorsTasks).ConfigureAwait(false);
+            return authors;
+        }
+
+        private static async Task<Author> ReadAuthor(Assembly assembly, string authorResourceName)
+        {
+            using var stream = assembly.GetManifestResourceStream(authorResourceName);
+            using var reader = new StreamReader(stream);
+            var json = await reader.ReadToEndAsync().ConfigureAwait(false);
+            var author = JsonConvert.DeserializeObject<Author>(json);
+            return author;
+        }
+    }
+}

--- a/PlanetXamarinAuthors/Models/Author.cs
+++ b/PlanetXamarinAuthors/Models/Author.cs
@@ -1,0 +1,40 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace PlanetXamarinAuthors.Models
+{
+    public class Author
+    {
+        [JsonProperty("firstName", Required = Required.DisallowNull)]
+        public string FirstName { get; set; }
+        [JsonProperty("lastName", Required = Required.DisallowNull)]
+        public string LastName { get; set; }
+        [JsonProperty("stateOrRegion", Required = Required.DisallowNull)]
+        public string StateOrRegion { get; set; }
+        [EmailAddress]
+        [JsonProperty("emailAddress", Required = Required.Always)]
+        public string EmailAddress { get; set; }
+        [JsonProperty("tagOrBio", Required = Required.DisallowNull)]
+        public string ShortBioOrTagLine { get; set; }
+        [Url]
+        [JsonProperty("webSite", Required = Required.Always)]
+        public Uri WebSite { get; set; }
+        [JsonProperty("twitterHandle", Required = Required.DisallowNull)]
+        public string TwitterHandle { get; set; }
+        [JsonProperty("githubHandle", Required = Required.Always)]
+        public string GitHubHandle { get; set; }
+        [JsonProperty("gravatarHash", Required = Required.DisallowNull)]
+        public string GravatarHash { get; set; }
+        [JsonProperty("feedUris", Required = Required.Always)]
+        public IEnumerable<Uri> FeedUris { get; set; }
+        [JsonProperty("position", Required = Required.DisallowNull)]
+        public GeoPosition Position { get; set; }
+
+        // In ISO 639-1, lowercase, 2 letters
+        // https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+        [JsonProperty("languageCode", Required = Required.Always)]
+        public string FeedLanguageCode { get; set; }
+    }
+}

--- a/PlanetXamarinAuthors/Models/GeoPosition.cs
+++ b/PlanetXamarinAuthors/Models/GeoPosition.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace PlanetXamarinAuthors.Models
+{
+    public class GeoPosition
+    {
+        public static GeoPosition Empty = new GeoPosition(-1337, 42);
+
+        [JsonProperty("lat", Required = Required.Always)]
+        public double Lat { get; }
+        [JsonProperty("lon", Required = Required.Always)]
+        public double Lng { get; }
+
+        public GeoPosition(double lat, double lng)
+        {
+            Lat = lat;
+            Lng = lng;
+        }
+    }
+}

--- a/PlanetXamarinAuthors/PlanetXamarinAuthors.csproj
+++ b/PlanetXamarinAuthors/PlanetXamarinAuthors.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\Authors\*.json" />
+  </ItemGroup>
+</Project>

--- a/author-schema.json
+++ b/author-schema.json
@@ -1,0 +1,88 @@
+{
+  {
+    "definitions": {
+      "GeoPosition": {
+        "type": "object",
+        "properties": {
+          "lat": {
+            "type": "number"
+          },
+          "lon": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "lat",
+          "lon"
+        ]
+      }
+    },
+    "type": "object",
+    "properties": {
+      "firstName": {
+        "description": "Author First Name",
+        "type": "string"
+      },
+      "lastName": {
+        "description": "Author Last Name",
+        "type": "string"
+      },
+      "stateOrRegion": {
+        "description": "Author State or Region",
+        "type": "string"
+      },
+      "emailAddress": {
+        "description": "E-mail address",
+        "type": "string",
+        "format": "email"
+      },
+      "tagOrBio": {
+        "description": "Tagline or bio",
+        "type": "string"
+      },
+      "webSite": {
+        "description": "Author Web Site",
+        "type": "string",
+        "format": "uri"
+      },
+      "feedUris": {
+        "description": "Feed URIs",
+        "type": "array",
+        "items": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        }
+      },
+      "twitterHandle": {
+        "description": "Author Twitter Handle",
+        "type": "string"
+      },
+      "gravatarHash": {
+        "description": "Author Gravatar Hash",
+        "type": "string"
+      },
+      "githubHandle": {
+        "description": "Author GitHub Handle",
+        "type": "string"
+      },
+      "position": {
+        "description": "Author GeoPosition",
+        "$ref": "#/definitions/GeoPosition"
+      },
+      "languageCode": {
+        "description": "Feed Language Code. ISO 639-1 format.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "emailAddress",
+      "webSite",
+      "feedUris",
+      "githubHandle",
+      "languageCode"
+    ]
+  }
+}


### PR DESCRIPTION
This one I made a while ago, so it will need a bit of updating of the function to newer tech. I can help with that in a separate PR.

The general idea of this Azure Function is to run periodically, right now it is scheduled to run every hour, to go through all author feeds and create combined feeds for all authors (mixed) and a feed for every language found in the author files.

I made a small App to convert the Author classes in PlanetXamarin to a new json based Author structure, that can easily be validated against a JSON schema. This could just as easily be YAML or whatever is decided upon, nothing set it stone.
These files contain the author information, such as urls of feeds, name, and language. I think it also contains a couple of other things like blerbs and geo positions for the web-page, but is not used by the function itself.

The feeds generated from the Function are uploaded to Azure Blob Storage as publicly accessible files. Just overwriting the existing files. Since these files are public we don't need to mess with SAS tokens for users to download feeds.

This PR relates to https://github.com/planetxamarin/planetxamarin/issues/733